### PR TITLE
Add Earl Reporter to run in the LDP Test Suite

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlReporter.java
@@ -1,0 +1,179 @@
+package org.w3.ldp.testsuite.reporter;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.openrdf.model.vocabulary.EARL;
+import org.testng.IReporter;
+import org.testng.IResultMap;
+import org.testng.ISuite;
+import org.testng.ISuiteResult;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+import org.testng.internal.Utils;
+import org.testng.xml.XmlSuite;
+import org.w3.ldp.testsuite.annotations.Reference;
+import org.w3.ldp.testsuite.vocab.Earl;
+
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
+import com.hp.hpl.jena.rdf.model.Resource;
+import com.hp.hpl.jena.vocabulary.DCTerms;
+
+/**
+ * Earl Reporter for the LDP Test Suite. Takes in the results of the test suite
+ * and reports the information to a Turtle file, which contains Earl vocabulary.
+ */
+public class LdpEarlReporter implements IReporter {
+
+	private BufferedWriter writer;
+	private Model model;
+
+	private static final String PASS = "TEST PASSED";
+	private static final String FAIL = "TEST FAILED";
+	private static final String SKIP = "TEST SKIPPED";
+	private static final String TURTLE = "TURTLE";
+	private static final String outputDir = "report"; // directory where results
+														// will go
+
+	@Override
+	public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites,
+			String outputDirectory) {
+		try {
+			createWriter(outputDir);
+		} catch (IOException e) {
+		}
+		createModel();
+		createAssertions(suites);
+		write();
+		try {
+			endWriter();
+		} catch (IOException e) {
+		}
+	}
+
+	private void createAssertions(List<ISuite> suites) {
+		for (ISuite suite : suites) {
+
+			Map<String, ISuiteResult> tests = suite.getResults();
+
+			for (ISuiteResult results : tests.values()) {
+				ITestContext testContext = results.getTestContext();
+				getResultProperties(testContext.getFailedTests(), FAIL,
+						suite.getName());
+				getResultProperties(testContext.getSkippedTests(), SKIP,
+						suite.getName());
+				getResultProperties(testContext.getPassedTests(), PASS,
+						suite.getName());
+			}
+
+		}
+
+	}
+
+	private void getResultProperties(IResultMap tests, String status,
+			String name) {
+		for (ITestResult result : tests.getAllResults()) {
+			makeResultResource(result, status, name);
+		}
+	}
+
+	private void makeResultResource(ITestResult result, String status,
+			String name) {
+		Resource assertionResource = model.createResource(null, Earl.Assertion);
+		Resource caseResource = model.createResource(null, Earl.TestCase);
+		Resource subjectResource = model.createResource(null, Earl.TestSubject);
+		Resource resultResource = model.createResource(null, Earl.TestResult);
+		Resource assertorResource = model.createResource(null, Earl.Assertor);
+		Resource modeResource = model.createResource(EARL.AUTOMATIC.toString(),
+				Earl.TestMode);
+
+		/* Add properties to the Test Subject Resource */
+		String declaringClass = result.getMethod().getConstructorOrMethod()
+				.getDeclaringClass().getName();
+		subjectResource.addProperty(DCTerms.description, "Declaring Class: "
+				+ declaringClass);
+
+		subjectResource.addProperty(DCTerms.title, result.getName());
+
+		/* Assertor Resource */
+		assertorResource.addProperty(DCTerms.title, name);
+
+		/* Test Criterion/Test Case Resource */
+		caseResource.addProperty(DCTerms.description, (result.getMethod()
+				.getDescription() != null ? result.getMethod().getDescription()
+				: "No Description available"));
+
+		String groups = groups(result.getMethod().getGroups());
+
+		caseResource.addProperty(DCTerms.subject, "Groups: " + groups);
+		if (result.getMethod().getConstructorOrMethod().getMethod()
+				.getAnnotation(Reference.class).uri() != null) {
+			caseResource.addProperty(DCTerms.relation,
+					result.getMethod().getConstructorOrMethod().getMethod()
+							.getAnnotation(Reference.class).uri());
+		}
+
+		/* Test Result Resource */
+		long time = result.getEndMillis() - result.getStartMillis();
+		resultResource.addLiteral(DCTerms.date, time + " Msec");
+		resultResource.addProperty(DCTerms.title, status);
+
+		if (result.getThrowable() != null) {
+			createExceptionProperty(result.getThrowable(), resultResource);
+		}
+
+		/* Add the above resources to the Assertion Resource */
+		assertionResource.addProperty(Earl.test, caseResource);
+		assertionResource.addProperty(Earl.testResult, resultResource);
+		assertionResource.addProperty(Earl.testSubject, subjectResource);
+		assertionResource.addProperty(Earl.assertedBy, assertorResource);
+		assertionResource.addProperty(Earl.mode, modeResource);
+	}
+
+	private void createExceptionProperty(Throwable thrown, Resource resource) {
+		if (thrown.getClass().getName().contains(SKIP))
+			resource.addProperty(Earl.outcome, thrown.getMessage());
+		else
+			resource.addLiteral(Earl.outcome,
+					Utils.stackTrace(thrown, false)[0]);
+	}
+
+	private String groups(String[] list) {
+		if (list.length == 0)
+			return null;
+		String retList = "";
+		for (int i = 0; i < list.length; i++) {
+			if (i == list.length - 1)
+				retList += list[i];
+			else
+				retList += list[i] + ", ";
+		}
+		return retList;
+	}
+
+	private void createWriter(String directory) throws IOException {
+		writer = null;
+		new File(directory).mkdirs();
+		writer = new BufferedWriter(new FileWriter(directory
+				+ "/EarlTestSuiteReport.ttl"));
+	}
+
+	private void write() {
+		model.write(writer, TURTLE);
+	}
+
+	private void endWriter() throws IOException {
+		writer.flush();
+		writer.close();
+	}
+
+	private void createModel() {
+		model = ModelFactory.createDefaultModel();
+	}
+
+}

--- a/src/main/java/org/w3/ldp/testsuite/vocab/Earl.java
+++ b/src/main/java/org/w3/ldp/testsuite/vocab/Earl.java
@@ -1,0 +1,50 @@
+package org.w3.ldp.testsuite.vocab;
+
+import org.openrdf.model.vocabulary.EARL;
+
+import com.hp.hpl.jena.rdf.model.Property;
+import com.hp.hpl.jena.rdf.model.Resource;
+import com.hp.hpl.jena.rdf.model.ResourceFactory;
+
+public class Earl {
+
+	/* List of Earl Resources */
+	public final static Resource TestResult = resource(EARL.TESTRESULT
+			.toString());
+	public final static Resource TestCase = resource(EARL.NAMESPACE
+			+ "TestCase");
+	public final static Resource TestSubject = resource(EARL.TEST_SUBJECT
+			.toString());
+	public final static Resource Assertor = resource(EARL.ASSERTOR.toString());
+	public final static Resource Assertion = resource(EARL.ASSERTION.toString());
+	public final static Resource TestMode = resource(EARL.MODE.toString());
+
+	/* List of Earl Properties */
+	public final static Property testResult = property(EARL.RESULT.toString());
+	public final static Property testSubject = property(EARL.SUBJECT.toString());
+
+	public final static Property outcome = property(EARL.OUTCOME.toString());
+	public final static Property failed = property(EARL.FAIL.toString());
+	public final static Property passed = property(EARL.PASS.toString());
+	public final static Property skipped = property(EARL.NAMESPACE + "skip");
+
+	public final static Property time = property(EARL.NAMESPACE + "time");
+	public final static Property test = property(EARL.TEST.toString());
+
+	public final static Property software = property(EARL.ASSERTOR.toString());
+
+	public final static Property mode = property(EARL.MODE.toString());
+	public final static Property auto = property(EARL.AUTOMATIC.toString());
+
+	public final static Property assertedBy = property(EARL.ASSERTEDBY
+			.toString());
+
+	protected static final Property property(String name) {
+		return ResourceFactory.createProperty(name);
+	}
+
+	protected static final Resource resource(String name) {
+		return ResourceFactory.createResource(name);
+	}
+
+}

--- a/testng.xml
+++ b/testng.xml
@@ -4,15 +4,19 @@
 	<listeners>
 		<listener class-name='org.w3.ldp.testsuite.reporter.LdpTestListener' />
 		<listener class-name='org.w3.ldp.testsuite.reporter.LdpHtmlReporter' />
+		<listener class-name='org.w3.ldp.testsuite.reporter.LdpEarlReporter' />
 	</listeners>
 
-	<!-- <parameter name="basicContainer" value="http://localhost:8080/ldp/resources/" /> -->
+	<!-- <parameter name="basicContainer" value="http://localhost:8080/ldp/resources/" 
+		/> -->
 	<parameter name="directContainer" value="http://localhost:8080/ldp/resources/" />
-	<!-- <parameter name="indirectContainer" value="http://localhost:8080/ldp/resources/" /> -->
+	<!-- <parameter name="indirectContainer" value="http://localhost:8080/ldp/resources/" 
+		/> -->
 
 	<!-- Optional RDF member resource parameter. If left out, the tests will 
 		try to create a resource in one of the containers. -->
-	<!-- <parameter name="memberResource" value="http://localhost:8080/ldp/resources/bt1" /> -->
+	<!-- <parameter name="memberResource" value="http://localhost:8080/ldp/resources/bt1" 
+		/> -->
 
 	<test name="All Tests">
 		<groups>


### PR DESCRIPTION
Includes a report that generates a turtle file with Earl vocabulary.
Generates the .ttl file in the generated directory that the HTML report
is also located.

Change-Id: I952d2a2613c1c598e9d3aa73d53aaec0d9dfe848
Signed-off-by: ttsanton ttsanton@us.ibm.com
