### PR TITLE
Add Test Case Reporter with new Annotations

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/annotations/Implementation.java
+++ b/src/main/java/org/w3/ldp/testsuite/annotations/Implementation.java
@@ -1,0 +1,19 @@
+package org.w3.ldp.testsuite.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Implementation {
+
+	public static final String IMPLEMENTED = "implemented";
+	public static final String NOT_IMPLEMENTED = "not implemented";
+
+	public String implementation() default NOT_IMPLEMENTED;
+
+	public boolean isTestable() default true;
+
+	public boolean clientOnly() default false;
+	
+	public boolean manual() default false;
+}

--- a/src/main/java/org/w3/ldp/testsuite/annotations/Status.java
+++ b/src/main/java/org/w3/ldp/testsuite/annotations/Status.java
@@ -1,0 +1,16 @@
+package org.w3.ldp.testsuite.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Status {
+
+	public static final String APPROVED = "approved";
+	public static final String PENDING = "pending";
+	public static final String DEPRECATED = "deprecated";
+	public static final String EXTENSION = "extension";
+
+	String status() default PENDING;
+
+}

--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpTestCaseReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpTestCaseReporter.java
@@ -1,0 +1,430 @@
+package org.w3.ldp.testsuite.reporter;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.rendersnake.HtmlCanvas;
+import org.rendersnake.StringResource;
+
+import static org.rendersnake.HtmlAttributesFactory.*;
+
+import org.testng.annotations.Test;
+import org.w3.ldp.testsuite.test.BasicContainerTest;
+import org.w3.ldp.testsuite.test.CommonContainerTest;
+import org.w3.ldp.testsuite.test.CommonResourceTest;
+import org.w3.ldp.testsuite.test.DirectContainerTest;
+import org.w3.ldp.testsuite.test.IndirectContainerTest;
+import org.w3.ldp.testsuite.test.NonRDFSourceTest;
+import org.w3.ldp.testsuite.test.RdfSourceTest;
+import org.w3.ldp.testsuite.annotations.Implementation;
+import org.w3.ldp.testsuite.annotations.Reference;
+import org.w3.ldp.testsuite.annotations.Status;
+
+public class LdpTestCaseReporter {
+
+	private static HtmlCanvas html;
+
+	private static boolean initialRead;
+
+	private static Set<String> refURI = new HashSet<String>();
+
+	private static ArrayList<String> clients = new ArrayList<String>();
+	private static ArrayList<String> manuals = new ArrayList<String>();
+
+	private static int totalTests = 0;
+	private static int totalImplemented = 0;
+	private static int unimplemented = 0;
+	private static int coverage = 0;
+	private static int clientTest = 0;
+
+	private static int manual = 0;
+	private static int disabled = 0;
+
+	private static int must = 0;
+	private static int should = 0;
+	private static int may = 0;
+
+	private static int reqImpl = 0;
+
+	private static int mustImpl = 0;
+	private static int shouldImpl = 0;
+	private static int mayImpl = 0;
+
+	private static int refNotImpl = 0;
+	private static int mustNotImpl = 0;
+	private static int mayNotImpl = 0;
+	private static int shouldNotImpl = 0;
+
+	private static int pending = 0;
+	private static int approved = 0;
+
+	private static Class<BasicContainerTest> bcTest = BasicContainerTest.class;
+	private static Class<RdfSourceTest> rdfSourceTest = RdfSourceTest.class;
+	private static Class<IndirectContainerTest> indirectContainerTest = IndirectContainerTest.class;
+	private static Class<DirectContainerTest> directContienerTest = DirectContainerTest.class;
+	private static Class<CommonContainerTest> commonContainerTest = CommonContainerTest.class;
+	private static Class<CommonResourceTest> commonResourceTest = CommonResourceTest.class;
+	private static Class<NonRDFSourceTest> nonRdfSourceTest = NonRDFSourceTest.class;
+
+	public static void main(String[] args) throws IOException {
+		initialRead = false;
+		makeReport();
+
+		createWriter("report", html.toHtml());
+	}
+
+	private static void makeReport() throws IOException {
+		html = new HtmlCanvas();
+		html.html().head();
+		writeCss();
+		html._head().body().title().content("Test Cases Report");
+
+		html.h1().content("LDP Test Suite: Test Cases Report");
+
+		createSummaryReport();
+		toTop();
+
+		acquireTestCases(rdfSourceTest);
+		acquireTestCases(bcTest);
+		acquireTestCases(commonContainerTest);
+		acquireTestCases(commonResourceTest);
+		acquireTestCases(nonRdfSourceTest);
+		acquireTestCases(indirectContainerTest);
+		acquireTestCases(directContienerTest);
+	}
+
+	private static void createSummaryReport() throws IOException {
+
+		firstRead();
+
+		initialRead = true;
+		html.h2().content("Summary of Test Methods");
+		html.table(class_("summary"));
+		html.tr().th().content("Total Tests");
+		html.th().content("Overall Coverage");
+		html.th().content("Unimplemented Methods");
+		html._tr();
+
+		html.tr();
+		html.td().b().write("" + totalTests)._b()
+				.write(" Total Tests Running Against Specifications");
+		html.br().b().write(pending + " ")._b().write("Tests pending, ").b()
+				.write(approved + " ")._b().write("Tests approved");
+		html.ul();
+		html.li().b().write("" + coverage)._b().write(" Requirements Covered")
+				._li();
+		html.ul().li().b().write("" + must)._b().write(" MUST")._li();
+		html.li().b().write("" + should)._b().write(" SHOULD")._li();
+		html.li().b().write("" + may)._b().write(" MAY")._li()._ul();
+		html._ul();
+
+		html._td();
+
+		html.td();
+
+		html.b().write(totalImplemented + "/" + totalTests)._b()
+				.write(" of Total Tests Implemented");
+
+		html.ul();
+		html.li().b().write(reqImpl + " ")._b()
+				.write("Requirements Implemented")._li();
+		html.ul();
+		html.li().b().write(mustImpl + "/" + must)._b()
+				.write(" of MUST Tests Implemented")._li();
+		html.li().b().write(shouldImpl + "/" + should)._b()
+				.write(" of SHOULD Tests Implemented")._li();
+		html.li().b().write(mayImpl + "/" + may)._b()
+				.write(" of MAY Tests Implemented")._li();
+		html._ul();
+		html._ul();
+
+		html._td();
+
+		// html.td().content(totalImplemented + " Tests");
+		html.td();
+		html.b().write(unimplemented + " ")._b().write("of the Total Tests");
+		html.ul();
+
+		html.li().b().write(disabled + " ")._b()
+				.write("of the Total Tests not enabled")._li();
+		html.li().b().write(clientTest + " ")._b().write("of the Total are ")
+				.a(href("#clientTests")).write("Client-Based Tests")._a()._li();
+		html.li().b().write(manual + " ")._b()
+				.write("of the Total must be Tested ").a(href("#manualTests"))
+				.write("Manually")._a()._li();
+		html._ul();
+
+		html.write("From the Total, ");
+
+		html.ul();
+		html.li().b().write(refNotImpl + " ")._b()
+				.write("Requirements not Implemented")._li();
+		html.ul();
+		html.li().b().write(mustNotImpl + " ")._b().write("MUST")._li();
+		html.li().b().write(shouldNotImpl + " ")._b().write("SHOULD")._li();
+		html.li().b().write(mayNotImpl + " ")._b().write("MAY")._li();
+		html._ul();
+		html._ul()._td();
+		html._tr();
+		html._table();
+
+		generateListOfTestCases();
+
+	}
+
+	private static void firstRead() throws IOException {
+		acquireTestCases(rdfSourceTest);
+		acquireTestCases(bcTest);
+		acquireTestCases(commonContainerTest);
+		acquireTestCases(commonResourceTest);
+		acquireTestCases(nonRdfSourceTest);
+		acquireTestCases(indirectContainerTest);
+		acquireTestCases(directContienerTest);
+	}
+
+	private static void generateListOfTestCases() throws IOException {
+		html.h2().content("Implemented Test Classes");
+		html.ul();
+		html.li().a(href("#" + rdfSourceTest.getCanonicalName()))
+				.content(rdfSourceTest.getCanonicalName())._li();
+		html.li().a(href("#" + bcTest.getCanonicalName()))
+				.content(bcTest.getCanonicalName())._li();
+		html.li().a(href("#" + commonContainerTest.getCanonicalName()))
+				.content(commonContainerTest.getCanonicalName())._li();
+		html.li().a(href("#" + commonResourceTest.getCanonicalName()))
+				.content(commonResourceTest.getCanonicalName())._li();
+		html.li().a(href("#" + indirectContainerTest.getCanonicalName()))
+				.content(indirectContainerTest.getCanonicalName())._li();
+		html.li().a(href("#" + directContienerTest.getCanonicalName()))
+				.content(directContienerTest.getCanonicalName())._li();
+		html.li().a(href("#" + nonRdfSourceTest.getCanonicalName()))
+				.content(nonRdfSourceTest.getCanonicalName())._li();
+		html._ul();
+
+		html.h2().a(name("manualTests"))
+				.content("Tests that Must be Tested Manually")._h2();
+		generateList(manuals);
+		html.h2().a(name("clientTests")).content("Client-Based Test Cases")
+				._h2();
+		generateList(clients);
+
+	}
+
+	private static void generateList(ArrayList<String> list) throws IOException {
+		html.ul();
+		for (int i = 0; i < list.size(); i++) {
+			html.li().a(href("#" + list.get(i))).write(list.get(i))._a()._li();
+		}
+		html._ul();
+	}
+
+	private static <T> void acquireTestCases(Class<T> classType)
+			throws IOException {
+		String name = classType.getCanonicalName();
+		if (initialRead)
+			html.h2().a(name(name)).write("Test Class: " + name)._a()._h2();
+		Method[] bcMethods = classType.getDeclaredMethods();
+
+		if (initialRead)
+			html.ul();
+		for (Method method : bcMethods) {
+			if (method.isAnnotationPresent(Test.class)) {
+				if (!initialRead) {
+					totalTests++;
+					generateInformation(method, name);
+				} else {
+					html.li().b().a(name(method.getName()))
+							.write(method.getName() + ": ")._a()._b();
+					generateInformation(method, name);
+					html._li();
+				}
+			}
+		}
+		if (initialRead) {
+			html._ul();
+			toTop();
+		}
+	}
+
+	private static void generateInformation(Method method, String name)
+			throws IOException {
+
+		Reference ref = null;
+		Test test = null;
+		Status status = null;
+		Implementation implmnt = null;
+
+		if (initialRead) {
+			html.table(class_("annotation"));
+			html.tr().th().content("Annotation Type");
+			html.th().content("Information")._tr();
+		}
+
+		if (method.getAnnotation(Test.class) != null) {
+			test = method.getAnnotation(Test.class);
+
+			if (!initialRead) {
+				if (!test.enabled())
+					disabled++;
+			} else {
+				html.tr().td()
+						.content(test.annotationType().getCanonicalName());
+				html.td();
+				html.b().write("Description: ")._b().write(test.description());
+				html.br().b().write("Groups: ")._b()
+						.write(Arrays.toString(test.groups()));
+				html.br().b().write("Enabled: ")._b()
+						.write("" + test.enabled())._td();
+				html._tr();
+			}
+
+		}
+
+		if (method.getAnnotation(Implementation.class) != null) {
+			implmnt = method.getAnnotation(Implementation.class);
+			if (!initialRead) {
+				if (implmnt.implementation().equals(Implementation.IMPLEMENTED)
+						&& !implmnt.clientOnly() && implmnt.isTestable()
+						&& (test != null && test.enabled())) {
+					totalImplemented++;
+				}
+				if (implmnt.implementation().equals(
+						Implementation.NOT_IMPLEMENTED)
+						|| implmnt.clientOnly()
+						|| !implmnt.isTestable()
+						|| (test != null && !test.enabled())) {
+					unimplemented++;
+				}
+				if (implmnt.clientOnly()) {
+					clientTest++;
+					clients.add(method.getName());
+				}
+				if (implmnt.manual()) {
+					manual++;
+					manuals.add(method.getName());
+				}
+			} else {
+				html.tr().td()
+						.content(implmnt.annotationType().getCanonicalName());
+				html.br().td().b().write("Implementation: ")._b()
+						.write(implmnt.implementation());
+				html.br().b().write("Manual Test: ")._b()
+						.write("" + implmnt.manual());
+				html.br().b().write("Client Only: ")._b()
+						.write("" + implmnt.clientOnly());
+				html._td();
+				html._tr();
+			}
+		}
+
+		if (method.getAnnotation(Reference.class) != null) {
+			ref = method.getAnnotation(Reference.class);
+			if (!initialRead) {
+				if (implmnt != null && test != null) {
+					if (!refURI.contains(ref.uri())) {
+						coverage++;
+						String group = Arrays.toString(test.groups());
+						if (group.contains("MUST"))
+							must++;
+						if (group.contains("SHOULD"))
+							should++;
+						if (group.contains("MAY"))
+							may++;
+
+						refURI.add(ref.uri());
+						if (implmnt.implementation().equals(
+								Implementation.IMPLEMENTED)) {
+							reqImpl++;
+							if (group.contains("MUST"))
+								mustImpl++;
+							if (group.contains("SHOULD"))
+								shouldImpl++;
+							if (group.contains("MAY"))
+								mayImpl++;
+
+						}
+						if (implmnt.implementation().equals(
+								Implementation.NOT_IMPLEMENTED)) {
+							refNotImpl++;
+
+							if (group.contains("MUST"))
+								mustNotImpl++;
+							if (group.contains("SHOULD"))
+								shouldNotImpl++;
+							if (group.contains("MAY"))
+								mayNotImpl++;
+						}
+
+					}
+				}
+			} else {
+				html.tr().td().content(ref.annotationType().getCanonicalName());
+				html.td().b().write("Reference URI: ")._b().a(href(ref.uri()))
+						.write(ref.uri())._a()._td();
+				html._tr();
+			}
+		}
+
+		if (method.getAnnotation(Status.class) != null) {
+			status = method.getAnnotation(Status.class);
+			if (!initialRead) {
+				if (status.status().equals(Status.PENDING))
+					pending++;
+				if (status.status().equals(Status.APPROVED))
+					approved++;
+			} else {
+				html.tr().td()
+						.content(status.annotationType().getCanonicalName());
+				html.td().b().write("Status: ")._b().write(status.status())
+						._td();
+				html._tr();
+			}
+		}
+
+		if (initialRead) {
+			html._table();
+			toTestClass(name);
+		}
+	}
+
+	private static void toTop() throws IOException {
+		html.p(class_("totop")).a(href("#top")).content("Back to Top")._p();
+	}
+
+	private static void toTestClass(String name) throws IOException {
+		html.p(class_("totest")).a(href("#" + name))
+				.content("Back to Main Test Class")._p();
+	}
+
+	private static void writeCss() throws IOException {
+
+		html.style().write(StringResource.get("testCaseStyle.css"), NO_ESCAPE)
+				._style();
+	}
+
+	private static void createWriter(String directory, String output) {
+		BufferedWriter writer = null;
+		new File(directory).mkdirs();
+		try {
+			writer = new BufferedWriter(new FileWriter(directory
+					+ "/LdpTestCasesHtmlReport.html"));
+			writer.write(output);
+
+		} catch (IOException e) {
+		} finally {
+			try {
+				if (writer != null)
+					writer.close();
+			} catch (IOException e) {
+			}
+		}
+	}
+
+}

--- a/src/main/java/org/w3/ldp/testsuite/test/BasicContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/BasicContainerTest.java
@@ -12,66 +12,76 @@ import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.w3.ldp.testsuite.LdpTestSuite;
+import org.w3.ldp.testsuite.annotations.Implementation;
 import org.w3.ldp.testsuite.annotations.Reference;
+import org.w3.ldp.testsuite.annotations.Status;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.vocabulary.RDF;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.response.Response;
+
 import org.w3.ldp.testsuite.vocab.LDP;
 
 public class BasicContainerTest extends CommonContainerTest {
 
-    private String basicContainer;
+	private String basicContainer;
 
-    @Parameters("basicContainer")
-    public BasicContainerTest(@Optional String basicContainer) {
-        this.basicContainer = basicContainer;
-    }
+	@Parameters("basicContainer")
+	public BasicContainerTest(@Optional String basicContainer) {
+		this.basicContainer = basicContainer;
+	}
 
-    @BeforeClass(alwaysRun = true)
-    public void hasBasicContainer() {
-        if (basicContainer == null) {
-            throw new SkipException("No basicContainer parameter provided in testng.xml. Skipping ldp:basicContainer tests.");
-        }
-    }
+	@BeforeClass(alwaysRun = true)
+	public void hasBasicContainer() {
+		if (basicContainer == null) {
+			throw new SkipException(
+					"No basicContainer parameter provided in testng.xml. Skipping ldp:basicContainer tests.");
+		}
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers exposing LDPCs MUST advertise their "
-                    + "LDP support by exposing a HTTP Link header with a "
-                    + "target URI matching the type of container (see below) "
-                    + "the server supports, and a link relation type of type "
-                    + "(that is, rel='type') in all responses to requests made "
-                    + "to the LDPC's HTTP Request-URI.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr")
-    public void testContainerSupportsHttpLinkHeader() throws URISyntaxException {
-        Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
-                .expect().statusCode(HttpStatus.SC_OK).when()
-                .get(new URI(basicContainer));
-        assertTrue(
-                hasLinkHeader(response, LDP.BasicContainer.stringValue(), LINK_REL_TYPE),
-                "LDP BasicContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <" + LDP.BasicContainer.stringValue() + "> and rel='type'");
-    }
+	@Test(groups = { MUST }, description = "LDP servers exposing LDPCs MUST advertise their "
+			+ "LDP support by exposing a HTTP Link header with a "
+			+ "target URI matching the type of container (see below) "
+			+ "the server supports, and a link relation type of type "
+			+ "(that is, rel='type') in all responses to requests made "
+			+ "to the LDPC's HTTP Request-URI.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testContainerSupportsHttpLinkHeader() throws URISyntaxException {
+		Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
+				.expect().statusCode(HttpStatus.SC_OK).when()
+				.get(new URI(basicContainer));
+		assertTrue(
+				hasLinkHeader(response, LDP.BasicContainer.stringValue(),
+						LINK_REL_TYPE),
+				"LDP BasicContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <"
+						+ LDP.BasicContainer.stringValue() + "> and rel='type'");
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "Each LDP Basic Container MUST also be a "
-                    + "conforming LDP Container in section 5.2 Container "
-                    + "along the following restrictions in this section.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpbc-are-ldpcs")
-    public void testContainerTypeIsBasicContainer() throws URISyntaxException {
-        // FIXME: We're just testing the RDF type here. We're not really testing the requirement.
-        Model containerModel = getAsModel(basicContainer);
-        Resource container = containerModel.getResource(basicContainer);
-        assertTrue(container.hasProperty(RDF.type, LDP.BasicContainer.stringValue()),
-                "Could not locate LDP BasicContainer rdf:type for <" + basicContainer + ">");
-    }
+	@Test(groups = { MUST }, description = "Each LDP Basic Container MUST also be a "
+			+ "conforming LDP Container in section 5.2 Container "
+			+ "along the following restrictions in this section.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpbc-are-ldpcs")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testContainerTypeIsBasicContainer() throws URISyntaxException {
+		// FIXME: We're just testing the RDF type here. We're not really testing
+		// the requirement.
+		Model containerModel = getAsModel(basicContainer);
+		Resource container = containerModel.getResource(basicContainer);
+		assertTrue(
+				container.hasProperty(RDF.type,
+						LDP.BasicContainer.stringValue()),
+				"Could not locate LDP BasicContainer rdf:type for <"
+						+ basicContainer + ">");
+	}
 
-    @Override
-    protected String getResourceUri() {
-        return basicContainer;
-    }
+	@Override
+	protected String getResourceUri() {
+		return basicContainer;
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
@@ -18,7 +18,9 @@ import org.testng.SkipException;
 import org.testng.annotations.Test;
 import org.w3.ldp.testsuite.LdpTestSuite;
 import org.w3.ldp.testsuite.http.HttpMethod;
+import org.w3.ldp.testsuite.annotations.Implementation;
 import org.w3.ldp.testsuite.annotations.Reference;
+import org.w3.ldp.testsuite.annotations.Status;
 import org.w3.ldp.testsuite.exception.SkipClientTestException;
 import org.w3.ldp.testsuite.mapper.RdfObjectMapper;
 
@@ -38,501 +40,527 @@ import org.w3.ldp.testsuite.vocab.LDP;
  */
 public abstract class CommonContainerTest extends RdfSourceTest {
 
-    public static final String MSG_LOC_NOTFOUND = "Location header missing after POST create.";
-    public static final String MSG_MBRRES_NOTFOUND = "Unable to locate object in triple with predicate ldp:membershipResource.";
-
-    @Test(
-            groups = {MAY},
-            description = "LDP servers MAY choose to allow the creation of new "
-                    + "resources using HTTP PUT.")
-    @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-put-create")
-    public void testPutToCreate() throws URISyntaxException {
-    	String location = putToCreate();
-    	RestAssured.expect().statusCode(isSuccessful()).when().delete(new URI(location));
-    }
-
-    @Test(
-            enabled = false,
-            groups = {MUST},
-            description = "LDP servers MUST assign the default base-URI "
-                    + "for [RFC3987] relative-URI resolution to be the HTTP "
-                    + "Request-URI when the resource already exists, and to "
-                    + "the URI of the created resource when the request results "
-                    + "in the creation of a new resource.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-gen-defbaseuri")
-    public void testRelativeUriResolutionPost() {
-
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDPC representations SHOULD NOT use RDF container "
-                    + "types rdf:Bag, rdf:Seq or rdf:List.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-nordfcontainertypes")
-    public void testNoRdfBagSeqOrList() throws URISyntaxException {
-        Model containerModel = getAsModel(getResourceUri());
-        assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.Bag).hasNext(), "LDPC representations should not use rdf:Bag");
-        assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.Seq).hasNext(), "LDPC representations should not use rdf:Seq");
-        assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.List).hasNext(), "LDPC representations should not use rdf:List");
-    }
-
-    @Test(
-            groups = {SHOULD},
-            enabled = false, // not implemented
-            description = "LDP servers SHOULD respect all of a client's LDP-defined "
-                    + "hints, for example which subsets of LDP-defined state the "
-                    + "client is interested in processing, to influence the set of "
-                    + "triples returned in representations of an LDPC, particularly for "
-                    + "large LDPCs. See also [LDP-PAGING].")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-prefer")
-    public void testClientHints() {
-
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDPC clients SHOULD create member resources by "
-                    + "submitting a representation as the entity body of the "
-                    + "HTTP POST to a known LDPC.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-created201")
-    public void testClientPostToCreate() {
-        throw new SkipClientTestException();
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "If the resource was created successfully, LDP servers MUST "
-                    + "respond with status code 201 (Created) and the Location "
-                    + "header set to the new resource’s URL. Clients shall not "
-                    + "expect any representation in the response entity body on "
-                    + "a 201 (Created) response.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-created201")
-    public void testPostResponseStatusAndLocation() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Model model = postContent();
-        Response postResponse = RestAssured
-                .given().contentType(TEXT_TURTLE).body(model, new RdfObjectMapper())
-                .expect().statusCode(HttpStatus.SC_CREATED)
-                .when().post(new URI(getResourceUri()));
-
-        String location = postResponse.getHeader(LOCATION);
-        assertNotNull(location, MSG_LOC_NOTFOUND);
-
-        RestAssured.expect().statusCode(isSuccessful()).when().delete(new URI(location));
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "When a successful HTTP POST request to an LDPC results "
-                    + "in the creation of an LDPR, a containment triple MUST be "
-                    + "added to the state of LDPC.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-createdmbr-contains")
-    public void testPostContainer() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Model model = postContent();
-        String containerUri = getResourceUri();
-        Response postResponse = RestAssured
-                .given().contentType(TEXT_TURTLE).body(model, new RdfObjectMapper())
-                .expect().statusCode(HttpStatus.SC_CREATED)
-                .when().post(new URI(getResourceUri()));
-
-        String location = postResponse.getHeader(LOCATION);
-        assertNotNull(location, MSG_LOC_NOTFOUND);
-
-        Model containerModel = getAsModel(containerUri);
-        Resource container = containerModel.getResource(containerUri);
-
-        assertTrue(container.hasProperty(containerModel.createProperty(LDP.contains.stringValue()), containerModel.getResource(location)),
-                "Container <" + containerUri + "> does not have a containment triple for newly created resource <" + location + ">.");
-
-        RestAssured.expect().statusCode(isSuccessful()).when().delete(new URI(location));
-    }
-
-    @Test(
-            groups = {MUST},
-            enabled = false, // not implemented
-            description = "LDP servers that successfully create a resource from a "
-                    + "RDF representation in the request entity body MUST honor the "
-                    + "client's requested interaction model(s). The created resource "
-                    + "can be thought of as an RDF named graph [rdf11-concepts]. If any "
-                    + "model cannot be honored, the server MUST fail the request.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-createrdf")
-    public void testRequestedInteractionModel() {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        // ...
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "LDP servers MUST accept a request entity body with a "
-                    + "request header of Content-Type with value of text/turtle [turtle].")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-turtle")
-    public void testAcceptTurtle() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Model model = postContent();
-        Response postResponse = RestAssured
-                .given().contentType(TEXT_TURTLE).body(model, new RdfObjectMapper())
-                .expect().statusCode(HttpStatus.SC_CREATED)
-                .when().post(new URI(getResourceUri()));
-
-        // Delete the resource to clean up.
-        String location = postResponse.getHeader(LOCATION);
-        if (location != null) {
-            RestAssured.expect().statusCode(isSuccessful()).when().delete(new URI(location));
-        }
-    }
-
-    @Test(
-            groups = {SHOULD},
-            enabled = false,
-            description = "LDP servers SHOULD use the Content-Type request header to "
-                    + "determine the representation format when the request has an "
-                    + "entity body.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-contenttype")
-    public void testContentTypeHeader() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        // TODO: Determine how to best test this.
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "In RDF representations, LDP servers MUST interpret the null relative "
-                    + "URI for the subject of triples in the LDPR representation in the request "
-                    + "entity body as referring to the entity in the request body. Commonly, that "
-                    + "entity is the model for the “to be created” LDPR, so triples whose subject "
-                    + "is the null relative URI will usually result in triples in the created "
-                    + "resource whose subject is the created resource.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-rdfnullrel")
-    public void testNullRelativeUri() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Model requestModel = ModelFactory.createDefaultModel();
-        Resource resource = requestModel.createResource("");
-        String identifier = UUID.randomUUID().toString();
-        resource.addProperty(DCTerms.identifier, identifier);
-
-        Response postResponse = RestAssured
-                .given().contentType(TEXT_TURTLE).body(requestModel, new RdfObjectMapper(getResourceUri()))
-                .expect().statusCode(HttpStatus.SC_CREATED)
-                .when().post(new URI(getResourceUri()));
-
-        String location = postResponse.getHeader(LOCATION);
-        assertNotNull(location, MSG_LOC_NOTFOUND);
-
-        // Get the resource to check that the resource with a null relative URI
-        // was assigned the URI in the Location response header.
-        Model responseModel = getAsModel(location);
-        Resource created = responseModel.getResource(location);
-
-        // TODO: Is this the best test? It's possible a server will assign its own dcterms:identifier.
-        assertTrue(created.hasProperty(DCTerms.identifier, identifier),
-                "The resource created with URI <" + location + "> does not have the dcterms:identifier as the resource POSTed using the null relative URI.");
-
-        // Delete the resource to clean up.
-        RestAssured.expect().statusCode(isSuccessful()).when().delete(new URI(location));
-    }
-
-    @Test(
-            groups = {SHOULD},
-            enabled = false, // not implemented
-            description = "LDP servers SHOULD assign the URI for the resource to be created "
-                    + "using server application specific rules in the absence of a client hint.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-serverassignuri")
-    public void testAssignUri() {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        // ...
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers SHOULD allow clients to create new resources without "
-                    + "requiring detailed knowledge of application-specific constraints. This "
-                    + "is a consequence of the requirement to enable simple creation and "
-                    + "modification of LDPRs. LDP servers expose these application-specific "
-                    + "constraints as described in section 4.2.1 General.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-mincontraints")
-    public void testCreateWithoutConstraints() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        // Create a resource with one statement (dcterms:identifier).
-        Model requestModel = ModelFactory.createDefaultModel();
-        Resource resource = requestModel.createResource("");
-        String identifier = UUID.randomUUID().toString();
-        resource.addProperty(DCTerms.identifier, identifier);
-
-        Response postResponse =
-                RestAssured.given().contentType(TEXT_TURTLE).body(requestModel, new RdfObjectMapper())
-                        .expect().statusCode(HttpStatus.SC_CREATED)
-                        .when().post(new URI(getResourceUri()));
-
-        // Delete the resource to clean up.
-        String location = postResponse.getHeader(LOCATION);
-        if (location != null) {
-            RestAssured.expect().statusCode(isSuccessful()).when().delete(new URI(location));
-        }
-
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers that allow member creation via POST SHOULD NOT re-use URIs.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-dontreuseuris")
-    public void testRestrictUriReUseSlug() throws URISyntaxException {
-        testRestrictUriReUse("uritest");
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers that allow member creation via POST SHOULD NOT re-use URIs.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-dontreuseuris")
-    public void testRestrictUriReUseNoSlug() throws URISyntaxException {
-        testRestrictUriReUse(null);
-    }
-
-    @Test(
-            groups = {MAY},
-            enabled = false, // not implemented
-            description = "Upon successful creation of an LDP-NR (HTTP status code of 201-Created "
-                    + "and URI indicated by Location response header), LDP servers MAY create an "
-                    + "associated LDP-RS to contain data about the newly created LDP-NR.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbinlinkmetahdr")
-    public void testCreateAssociatedRdfSource() {
-
-    }
-
-    @Test(
-            groups = {MUST},
-            enabled = false, // not implemented
-            dependsOnMethods = {"testCreateAssociatedRdfSource"},
-            description = "If an LDPC server creates this associated LDP-RS it MUST indicate "
-                    + "its location on the HTTP response using the HTTP Link response header "
-                    + "with link relation describedby and href to be the URI of the associated "
-                    + "LDP-RS resource [RFC5988].")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbinlinkmetahdr")
-    public void testAssociatedRdfSourceLinkResponseHeader() {
-
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "LDP servers that support POST MUST include an Accept-Post "
-                    + "response header on HTTP OPTIONS responses, listing post document "
-                    + "media type(s) supported by the server.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-acceptposthdr")
-    public void testAcceptPostResponseHeader() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Response optionsResponse = RestAssured.expect().statusCode(isSuccessful())
-                .when().options(new URI(getResourceUri()));
-        assertNotNull(optionsResponse.getHeader(ACCEPT_POST),
-                "The HTTP OPTIONS response on container <" + getResourceUri() + "> did not include an Accept-Post response header, but it lists POST in its Allow response header.");
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers SHOULD NOT allow HTTP PUT to update an LDPC’s "
-                    + "containment triples; if the server receives such a request, it "
-                    + "SHOULD respond with a 409 (Conflict) status code.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-put-mbrprops")
-    public void testRejectPutModifyingContainmentTriples() {
-    	String containerUri = getResourceUri();
-    	Response response = RestAssured
-    			.given().header(ACCEPT, TEXT_TURTLE)
-    			.expect().statusCode(isSuccessful())
-    			.when().get(containerUri);
-    	String eTag = response.getHeader(ETAG);
-    	Model model = response.as(Model.class, new RdfObjectMapper(containerUri));
-    	
-    	// Try to modify the ldp:contains triple.
-    	Resource containerResource = model.getResource(containerUri);
-    	containerResource.addProperty(model.createProperty(LDP.contains.stringValue()),
-    			model.createResource("#foo"));
-
-    	RequestSpecification putRequest = RestAssured.given().contentType(TEXT_TURTLE);
-    	if (eTag != null) {
-    		putRequest.header(IF_MATCH, eTag);
-    	}
-    	putRequest.body(model, new RdfObjectMapper(containerUri))
-    		.expect().statusCode(not(isSuccessful()))
-    		.when().put(containerUri);
-    }
-
-    @Test(
-            groups = {SHOULD},
-            dependsOnMethods = { "testPutToCreate" },
-            description = "LDP servers that allow LDPR creation via PUT SHOULD NOT "
-                    + "re-use URIs. For RDF representations (LDP-RSs),the created "
-                    + "resource can be thought of as an RDF named graph [rdf11-concepts].")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-put-create")
-    public void testRestrictPutReUseUri() throws URISyntaxException {
-    	String location = putToCreate();
-    	URI uri = new URI(location);
-    	
-    	// Delete the resource.
-    	RestAssured
-    		.expect()
-    			.statusCode(isSuccessful())
-    		.when()
-    			.delete(uri);
-
-    	// Try to put to the same URI again. It should fail.
-    	Model content = postContent();
-    	RestAssured
-    		.given()
-    			.body(content, new RdfObjectMapper(location))
-    			.contentType(TEXT_TURTLE)
-    		.expect()
-    			.statusCode(not(isSuccessful()))
-    		.when()
-    			.put(uri);
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "When an LDPR identified by the object of a containment triple "
-                    + "is deleted, the LDPC server MUST also remove the LDPR from the "
-                    + "containing LDPC by removing the corresponding containment triple.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-del-contremovesconttriple")
-    public void testDeleteRemovesContainmentTriple() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Model model = postContent();
-        Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
-                .body(model, new RdfObjectMapper()).expect()
-                .statusCode(HttpStatus.SC_CREATED).when()
-                .post(new URI(getResourceUri()));
-
-        // POST support is optional. Only test delete if the POST succeeded.
-        if (postResponse.getStatusCode() != HttpStatus.SC_CREATED) {
-            throw new SkipException("HTTP POST failed with status " + postResponse.getStatusCode());
-        }
-
-        String location = postResponse.getHeader(LOCATION);
-        assertNotNull(location, MSG_LOC_NOTFOUND);
-
-        // TODO: Check if delete is supported on location.....
-
-        // Delete the resource
-        RestAssured.expect().statusCode(isSuccessful()).when().delete(new URI(location));
-
-        // Test the membership triple
-        Model containerModel = getAsModel(getResourceUri());
-        Resource container = containerModel.getResource(getResourceUri());
-
-        assertFalse(container.hasProperty(containerModel.createProperty(LDP.contains.stringValue()), containerModel.getResource(location)),
-                "The LDPC server must remove the corresponding containment triple when an LDPR is deleted.");
-    }
-
-    @Test(
-            groups = {MUST},
-            enabled = false, // not implemented
-            description = "When an LDPR identified by the object of a containment triple "
-                    + "is deleted, and the LDPC server created an associated LDP-RS "
-                    + "(see the LDPC POST section), the LDPC server MUST also remove the "
-                    + "associated LDP-RS it created.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-del-contremovescontres")
-    public void testDeleteContainerAssociatedResource() {
-
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers are RECOMMENDED to support HTTP PATCH as the "
-                    + "preferred method for updating an LDPC's empty-container triples. ")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-patch-req")
-    public void testPatchMethod() {
-        assertTrue(supports(HttpMethod.PATCH),
-                "Container <" + getResourceUri() + "> has not advertised PATCH support through its HTTP OPTIONS response.");
-
-        // TODO: Actually try to patch the containment triples.
-    }
-
-    @Test(
-            groups = {MUST},
-            enabled = false, // not implemented
-            description = "When an LDPC server creates an LDP-NR (for example, one "
-                    + "whose representation was HTTP POSTed to the LDPC) the LDP "
-                    + "server might create an associated LDP-RS to contain data about "
-                    + "the non-LDPR (see LDPC POST section). For LDP-NRs that have this "
-                    + "associated LDP-RS, an LDPC server MUST provide an HTTP Link "
-                    + "header whose target URI is the associated LDP-RS, and whose link "
-                    + "relation type is describedby [RFC5988].")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-options-linkmetahdr")
-    public void testProvideLinkHeaderAssociatedRdfSource() {
-
-    }
-
-    protected boolean restrictionsOnContent() {
-    	return false;
-    }
-
-    /**
-     * Tests that LDP servers do not reuse URIs after deleting resources.
-     * 
-     * @param slug the slug header for the request or null if no slug
-     * 
-     * @throws URISyntaxException on bad URIs
-     *
-     * @see #testRestrictUriReUseSlug()
-     * @see #testRestrictUriReUseNoSlug()
-     */
-    private void testRestrictUriReUse(String slug) throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        // POST two resources with the same Slug header and content to make sure they have different URIs.
-        Model content = postContent();
-        String loc1 = post(content, slug);
-
-        // TODO: Test if DELETE is supported before trying to delete the resource.
-        // Delete the resource to make sure the server doesn't reuse the URI below.
-        RestAssured.expect().statusCode(isSuccessful()).when().delete(new URI(loc1));
-
-        String loc2 = post(content, slug);
-        assertNotEquals(loc1, loc2, "Server reused URIs for POSTed resources.");
-    }
-
-    private String post(Model content, String slug) throws URISyntaxException {
-        RequestSpecification spec = RestAssured.given().contentType(TEXT_TURTLE);
-        if (slug != null) {
-            spec.header(SLUG, slug);
-        }
-        Response post = spec.body(content, new RdfObjectMapper())
-                .expect().statusCode(HttpStatus.SC_CREATED)
-                .when().post(new URI(getResourceUri()));
-        String location = post.getHeader(LOCATION);
-        assertNotNull(location, MSG_LOC_NOTFOUND);
-
-        return location;
-    }
-
-    /**
-     * Attempts to create a new resource using PUT.
-     * 
-     * @return the location of the created resource
-     * @see #testPutToCreate()
-     * @see #testRestrictPutReUseUri()
-     */
+	public static final String MSG_LOC_NOTFOUND = "Location header missing after POST create.";
+	public static final String MSG_MBRRES_NOTFOUND = "Unable to locate object in triple with predicate ldp:membershipResource.";
+
+	@Test(groups = { MAY }, description = "LDP servers MAY choose to allow the creation of new "
+			+ "resources using HTTP PUT.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-put-create")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testPutToCreate() throws URISyntaxException {
+		String location = putToCreate();
+		RestAssured.expect().statusCode(isSuccessful()).when()
+				.delete(new URI(location));
+	}
+
+	@Test(enabled = false, groups = { MUST }, description = "LDP servers MUST assign the default base-URI "
+			+ "for [RFC3987] relative-URI resolution to be the HTTP "
+			+ "Request-URI when the resource already exists, and to "
+			+ "the URI of the created resource when the request results "
+			+ "in the creation of a new resource.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-gen-defbaseuri")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	public void testRelativeUriResolutionPost() {
+
+	}
+
+	@Test(groups = { SHOULD }, description = "LDPC representations SHOULD NOT use RDF container "
+			+ "types rdf:Bag, rdf:Seq or rdf:List.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-nordfcontainertypes")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testNoRdfBagSeqOrList() throws URISyntaxException {
+		Model containerModel = getAsModel(getResourceUri());
+		assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.Bag)
+				.hasNext(), "LDPC representations should not use rdf:Bag");
+		assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.Seq)
+				.hasNext(), "LDPC representations should not use rdf:Seq");
+		assertFalse(containerModel
+				.listResourcesWithProperty(RDF.type, RDF.List).hasNext(),
+				"LDPC representations should not use rdf:List");
+	}
+
+	@Test(groups = { SHOULD }, enabled = false, // not implemented
+	description = "LDP servers SHOULD respect all of a client's LDP-defined "
+			+ "hints, for example which subsets of LDP-defined state the "
+			+ "client is interested in processing, to influence the set of "
+			+ "triples returned in representations of an LDPC, particularly for "
+			+ "large LDPCs. See also [LDP-PAGING].")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-prefer")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	public void testClientHints() {
+
+	}
+
+	@Test(groups = { SHOULD }, description = "LDPC clients SHOULD create member resources by "
+			+ "submitting a representation as the entity body of the "
+			+ "HTTP POST to a known LDPC.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-created201")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED, clientOnly = true)
+	public void testClientPostToCreate() {
+		throw new SkipClientTestException();
+	}
+
+	@Test(groups = { MUST }, description = "If the resource was created successfully, LDP servers MUST "
+			+ "respond with status code 201 (Created) and the Location "
+			+ "header set to the new resource’s URL. Clients shall not "
+			+ "expect any representation in the response entity body on "
+			+ "a 201 (Created) response.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-created201")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testPostResponseStatusAndLocation() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Model model = postContent();
+		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(new URI(getResourceUri()));
+
+		String location = postResponse.getHeader(LOCATION);
+		assertNotNull(location, MSG_LOC_NOTFOUND);
+
+		RestAssured.expect().statusCode(isSuccessful()).when()
+				.delete(new URI(location));
+	}
+
+	@Test(groups = { MUST }, description = "When a successful HTTP POST request to an LDPC results "
+			+ "in the creation of an LDPR, a containment triple MUST be "
+			+ "added to the state of LDPC.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-createdmbr-contains")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testPostContainer() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Model model = postContent();
+		String containerUri = getResourceUri();
+		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(new URI(getResourceUri()));
+
+		String location = postResponse.getHeader(LOCATION);
+		assertNotNull(location, MSG_LOC_NOTFOUND);
+
+		Model containerModel = getAsModel(containerUri);
+		Resource container = containerModel.getResource(containerUri);
+
+		assertTrue(
+				container.hasProperty(containerModel
+						.createProperty(LDP.contains.stringValue()),
+						containerModel.getResource(location)),
+				"Container <"
+						+ containerUri
+						+ "> does not have a containment triple for newly created resource <"
+						+ location + ">.");
+
+		RestAssured.expect().statusCode(isSuccessful()).when()
+				.delete(new URI(location));
+	}
+
+	@Test(groups = { MUST }, enabled = false, // not implemented
+	description = "LDP servers that successfully create a resource from a "
+			+ "RDF representation in the request entity body MUST honor the "
+			+ "client's requested interaction model(s). The created resource "
+			+ "can be thought of as an RDF named graph [rdf11-concepts]. If any "
+			+ "model cannot be honored, the server MUST fail the request.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-createrdf")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	public void testRequestedInteractionModel() {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		// ...
+	}
+
+	@Test(groups = { MUST }, description = "LDP servers MUST accept a request entity body with a "
+			+ "request header of Content-Type with value of text/turtle [turtle].")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-turtle")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testAcceptTurtle() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Model model = postContent();
+		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(new URI(getResourceUri()));
+
+		// Delete the resource to clean up.
+		String location = postResponse.getHeader(LOCATION);
+		if (location != null) {
+			RestAssured.expect().statusCode(isSuccessful()).when()
+					.delete(new URI(location));
+		}
+	}
+
+	@Test(groups = { SHOULD }, enabled = false, description = "LDP servers SHOULD use the Content-Type request header to "
+			+ "determine the representation format when the request has an "
+			+ "entity body.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-contenttype")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	public void testContentTypeHeader() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		// TODO: Determine how to best test this.
+	}
+
+	@Test(groups = { MUST }, description = "In RDF representations, LDP servers MUST interpret the null relative "
+			+ "URI for the subject of triples in the LDPR representation in the request "
+			+ "entity body as referring to the entity in the request body. Commonly, that "
+			+ "entity is the model for the “to be created” LDPR, so triples whose subject "
+			+ "is the null relative URI will usually result in triples in the created "
+			+ "resource whose subject is the created resource.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-rdfnullrel")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testNullRelativeUri() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Model requestModel = ModelFactory.createDefaultModel();
+		Resource resource = requestModel.createResource("");
+		String identifier = UUID.randomUUID().toString();
+		resource.addProperty(DCTerms.identifier, identifier);
+
+		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
+				.body(requestModel, new RdfObjectMapper(getResourceUri()))
+				.expect().statusCode(HttpStatus.SC_CREATED).when()
+				.post(new URI(getResourceUri()));
+
+		String location = postResponse.getHeader(LOCATION);
+		assertNotNull(location, MSG_LOC_NOTFOUND);
+
+		// Get the resource to check that the resource with a null relative URI
+		// was assigned the URI in the Location response header.
+		Model responseModel = getAsModel(location);
+		Resource created = responseModel.getResource(location);
+
+		// TODO: Is this the best test? It's possible a server will assign its
+		// own dcterms:identifier.
+		assertTrue(
+				created.hasProperty(DCTerms.identifier, identifier),
+				"The resource created with URI <"
+						+ location
+						+ "> does not have the dcterms:identifier as the resource POSTed using the null relative URI.");
+
+		// Delete the resource to clean up.
+		RestAssured.expect().statusCode(isSuccessful()).when()
+				.delete(new URI(location));
+	}
+
+	@Test(groups = { SHOULD }, enabled = false, // not implemented
+	description = "LDP servers SHOULD assign the URI for the resource to be created "
+			+ "using server application specific rules in the absence of a client hint.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-serverassignuri")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	public void testAssignUri() {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		// ...
+	}
+
+	@Test(groups = { SHOULD }, description = "LDP servers SHOULD allow clients to create new resources without "
+			+ "requiring detailed knowledge of application-specific constraints. This "
+			+ "is a consequence of the requirement to enable simple creation and "
+			+ "modification of LDPRs. LDP servers expose these application-specific "
+			+ "constraints as described in section 4.2.1 General.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-mincontraints")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testCreateWithoutConstraints() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		// Create a resource with one statement (dcterms:identifier).
+		Model requestModel = ModelFactory.createDefaultModel();
+		Resource resource = requestModel.createResource("");
+		String identifier = UUID.randomUUID().toString();
+		resource.addProperty(DCTerms.identifier, identifier);
+
+		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
+				.body(requestModel, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(new URI(getResourceUri()));
+
+		// Delete the resource to clean up.
+		String location = postResponse.getHeader(LOCATION);
+		if (location != null) {
+			RestAssured.expect().statusCode(isSuccessful()).when()
+					.delete(new URI(location));
+		}
+
+	}
+
+	@Test(groups = { SHOULD }, description = "LDP servers that allow member creation via POST SHOULD NOT re-use URIs.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-dontreuseuris")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testRestrictUriReUseSlug() throws URISyntaxException {
+		testRestrictUriReUse("uritest");
+	}
+
+	@Test(groups = { SHOULD }, description = "LDP servers that allow member creation via POST SHOULD NOT re-use URIs.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-dontreuseuris")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testRestrictUriReUseNoSlug() throws URISyntaxException {
+		testRestrictUriReUse(null);
+	}
+
+	@Test(groups = { MAY }, enabled = false, // not implemented
+	description = "Upon successful creation of an LDP-NR (HTTP status code of 201-Created "
+			+ "and URI indicated by Location response header), LDP servers MAY create an "
+			+ "associated LDP-RS to contain data about the newly created LDP-NR.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbinlinkmetahdr")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	public void testCreateAssociatedRdfSource() {
+
+	}
+
+	@Test(groups = { MUST }, enabled = false, // not implemented
+	dependsOnMethods = { "testCreateAssociatedRdfSource" }, description = "If an LDPC server creates this associated LDP-RS it MUST indicate "
+			+ "its location on the HTTP response using the HTTP Link response header "
+			+ "with link relation describedby and href to be the URI of the associated "
+			+ "LDP-RS resource [RFC5988].")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbinlinkmetahdr")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	public void testAssociatedRdfSourceLinkResponseHeader() {
+
+	}
+
+	@Test(groups = { MUST }, description = "LDP servers that support POST MUST include an Accept-Post "
+			+ "response header on HTTP OPTIONS responses, listing post document "
+			+ "media type(s) supported by the server.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-post-acceptposthdr")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testAcceptPostResponseHeader() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Response optionsResponse = RestAssured.expect()
+				.statusCode(isSuccessful()).when()
+				.options(new URI(getResourceUri()));
+		assertNotNull(
+				optionsResponse.getHeader(ACCEPT_POST),
+				"The HTTP OPTIONS response on container <"
+						+ getResourceUri()
+						+ "> did not include an Accept-Post response header, but it lists POST in its Allow response header.");
+	}
+
+	@Test(groups = { SHOULD }, description = "LDP servers SHOULD NOT allow HTTP PUT to update an LDPC’s "
+			+ "containment triples; if the server receives such a request, it "
+			+ "SHOULD respond with a 409 (Conflict) status code.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-put-mbrprops")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testRejectPutModifyingContainmentTriples() {
+		String containerUri = getResourceUri();
+		Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
+				.expect().statusCode(isSuccessful()).when().get(containerUri);
+		String eTag = response.getHeader(ETAG);
+		Model model = response.as(Model.class,
+				new RdfObjectMapper(containerUri));
+
+		// Try to modify the ldp:contains triple.
+		Resource containerResource = model.getResource(containerUri);
+		containerResource.addProperty(
+				model.createProperty(LDP.contains.stringValue()),
+				model.createResource("#foo"));
+
+		RequestSpecification putRequest = RestAssured.given().contentType(
+				TEXT_TURTLE);
+		if (eTag != null) {
+			putRequest.header(IF_MATCH, eTag);
+		}
+		putRequest.body(model, new RdfObjectMapper(containerUri)).expect()
+				.statusCode(not(isSuccessful())).when().put(containerUri);
+	}
+
+	@Test(groups = { SHOULD }, dependsOnMethods = { "testPutToCreate" }, description = "LDP servers that allow LDPR creation via PUT SHOULD NOT "
+			+ "re-use URIs. For RDF representations (LDP-RSs),the created "
+			+ "resource can be thought of as an RDF named graph [rdf11-concepts].")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-put-create")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testRestrictPutReUseUri() throws URISyntaxException {
+		String location = putToCreate();
+		URI uri = new URI(location);
+
+		// Delete the resource.
+		RestAssured.expect().statusCode(isSuccessful()).when().delete(uri);
+
+		// Try to put to the same URI again. It should fail.
+		Model content = postContent();
+		RestAssured.given().body(content, new RdfObjectMapper(location))
+				.contentType(TEXT_TURTLE).expect()
+				.statusCode(not(isSuccessful())).when().put(uri);
+	}
+
+	@Test(groups = { MUST }, description = "When an LDPR identified by the object of a containment triple "
+			+ "is deleted, the LDPC server MUST also remove the LDPR from the "
+			+ "containing LDPC by removing the corresponding containment triple.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-del-contremovesconttriple")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testDeleteRemovesContainmentTriple() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Model model = postContent();
+		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(new URI(getResourceUri()));
+
+		// POST support is optional. Only test delete if the POST succeeded.
+		if (postResponse.getStatusCode() != HttpStatus.SC_CREATED) {
+			throw new SkipException("HTTP POST failed with status "
+					+ postResponse.getStatusCode());
+		}
+
+		String location = postResponse.getHeader(LOCATION);
+		assertNotNull(location, MSG_LOC_NOTFOUND);
+
+		// TODO: Check if delete is supported on location.....
+
+		// Delete the resource
+		RestAssured.expect().statusCode(isSuccessful()).when()
+				.delete(new URI(location));
+
+		// Test the membership triple
+		Model containerModel = getAsModel(getResourceUri());
+		Resource container = containerModel.getResource(getResourceUri());
+
+		assertFalse(
+				container.hasProperty(containerModel
+						.createProperty(LDP.contains.stringValue()),
+						containerModel.getResource(location)),
+				"The LDPC server must remove the corresponding containment triple when an LDPR is deleted.");
+	}
+
+	@Test(groups = { MUST }, enabled = false, // not implemented
+	description = "When an LDPR identified by the object of a containment triple "
+			+ "is deleted, and the LDPC server created an associated LDP-RS "
+			+ "(see the LDPC POST section), the LDPC server MUST also remove the "
+			+ "associated LDP-RS it created.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-del-contremovescontres")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	public void testDeleteContainerAssociatedResource() {
+
+	}
+
+	@Test(groups = { SHOULD }, description = "LDP servers are RECOMMENDED to support HTTP PATCH as the "
+			+ "preferred method for updating an LDPC's empty-container triples. ")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-patch-req")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testPatchMethod() {
+		assertTrue(
+				supports(HttpMethod.PATCH),
+				"Container <"
+						+ getResourceUri()
+						+ "> has not advertised PATCH support through its HTTP OPTIONS response.");
+
+		// TODO: Actually try to patch the containment triples.
+	}
+
+	@Test(groups = { MUST }, enabled = false, // not implemented
+	description = "When an LDPC server creates an LDP-NR (for example, one "
+			+ "whose representation was HTTP POSTed to the LDPC) the LDP "
+			+ "server might create an associated LDP-RS to contain data about "
+			+ "the non-LDPR (see LDPC POST section). For LDP-NRs that have this "
+			+ "associated LDP-RS, an LDPC server MUST provide an HTTP Link "
+			+ "header whose target URI is the associated LDP-RS, and whose link "
+			+ "relation type is describedby [RFC5988].")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-options-linkmetahdr")
+	public void testProvideLinkHeaderAssociatedRdfSource() {
+
+	}
+
+	protected boolean restrictionsOnContent() {
+		return false;
+	}
+
+	/**
+	 * Tests that LDP servers do not reuse URIs after deleting resources.
+	 * 
+	 * @param slug
+	 *            the slug header for the request or null if no slug
+	 * 
+	 * @throws URISyntaxException
+	 *             on bad URIs
+	 * 
+	 * @see #testRestrictUriReUseSlug()
+	 * @see #testRestrictUriReUseNoSlug()
+	 */
+	private void testRestrictUriReUse(String slug) throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		// POST two resources with the same Slug header and content to make sure
+		// they have different URIs.
+		Model content = postContent();
+		String loc1 = post(content, slug);
+
+		// TODO: Test if DELETE is supported before trying to delete the
+		// resource.
+		// Delete the resource to make sure the server doesn't reuse the URI
+		// below.
+		RestAssured.expect().statusCode(isSuccessful()).when()
+				.delete(new URI(loc1));
+
+		String loc2 = post(content, slug);
+		assertNotEquals(loc1, loc2, "Server reused URIs for POSTed resources.");
+	}
+
+	private String post(Model content, String slug) throws URISyntaxException {
+		RequestSpecification spec = RestAssured.given()
+				.contentType(TEXT_TURTLE);
+		if (slug != null) {
+			spec.header(SLUG, slug);
+		}
+		Response post = spec.body(content, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(new URI(getResourceUri()));
+		String location = post.getHeader(LOCATION);
+		assertNotNull(location, MSG_LOC_NOTFOUND);
+
+		return location;
+	}
+
+	/**
+	 * Attempts to create a new resource using PUT.
+	 * 
+	 * @return the location of the created resource
+	 * @see #testPutToCreate()
+	 * @see #testRestrictPutReUseUri()
+	 */
 	protected String putToCreate() {
-	    // Build a unique URI for the PUT request.
-    	URI target = UriBuilder.fromUri(getResourceUri()).path(UUID.randomUUID().toString()).build();
-    	Model model = postContent();
-    	Response response = RestAssured
-    			.given().contentType(TEXT_TURTLE).body(model, new RdfObjectMapper(""))
-    			.expect().statusCode(HttpStatus.SC_CREATED)
-    			.when().put(target);
+		// Build a unique URI for the PUT request.
+		URI target = UriBuilder.fromUri(getResourceUri())
+				.path(UUID.randomUUID().toString()).build();
+		Model model = postContent();
+		Response response = RestAssured.given().contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper("")).expect()
+				.statusCode(HttpStatus.SC_CREATED).when().put(target);
 
-    	String location = response.getHeader(LOCATION);
-    	if (location == null) {
-    		return target.toString();
-    	}
+		String location = response.getHeader(LOCATION);
+		if (location == null) {
+			return target.toString();
+		}
 
-	    return location;
-    }
+		return location;
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
@@ -15,7 +15,9 @@ import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.w3.ldp.testsuite.LdpTestSuite;
+import org.w3.ldp.testsuite.annotations.Implementation;
 import org.w3.ldp.testsuite.annotations.Reference;
+import org.w3.ldp.testsuite.annotations.Status;
 import org.w3.ldp.testsuite.exception.SkipMethodNotAllowedException;
 import org.w3.ldp.testsuite.http.HttpMethod;
 import org.w3.ldp.testsuite.mapper.RdfObjectMapper;
@@ -62,6 +64,8 @@ public abstract class CommonResourceTest extends LdpTest {
             description = "LDP servers MUST at least be"
                     + " HTTP/1.1 conformant servers [HTTP11].")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-gen-http")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testIsHttp11Server() throws URISyntaxException {
         RestAssured.expect().statusLine(containsString("HTTP/1.1")).when().head(new URI(getResourceUri()));
     }
@@ -74,6 +78,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "for LDP servers to need to host binary or text "
                     + "resources that do not have useful RDF representations.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-gen-binary")
+	@Status(status = Status.PENDING)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED)
     public void testOtherMediaTypes() {
 
     }
@@ -84,6 +90,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "(either weak or strong ones) as response "
                     + "ETag header values.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-gen-etags")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testETagHeadersGet() throws URISyntaxException {
         // GET requests
         RestAssured.given().header(ACCEPT, TEXT_TURTLE)
@@ -97,6 +105,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "(either weak or strong ones) as response "
                     + "ETag header values.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-gen-etags")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testETagHeadersHead() throws URISyntaxException {
         // GET requests
         RestAssured.given().header(ACCEPT, TEXT_TURTLE)
@@ -105,6 +115,7 @@ public abstract class CommonResourceTest extends LdpTest {
     }
 
     @Test(
+    		groups = {MUST},
             description = "LDP servers exposing LDPRs MUST advertise "
                     + "their LDP support by exposing a HTTP Link header "
                     + "with a target URI of http://www.w3.org/ns/ldp#Resource, "
@@ -112,6 +123,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "in all responses to requests made to the LDPR's "
                     + "HTTP Request-URI.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-gen-linktypehdr")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testLdpLinkHeader() throws URISyntaxException {
         Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
                 .expect().statusCode(isSuccessful())
@@ -133,6 +146,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "the URI of the created resource when the request results "
                     + "in the creation of a new resource.")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-gen-defbaseuri")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testRelativeUriResolutionPut() throws URISyntaxException {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
 
@@ -171,6 +186,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "with rel='describedby' [RFC5988] to all responses to requests "
                     + "which fail due to violation of those constraints.")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-gen-pubclireqs")
+	@Status(status = Status.PENDING)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED)
     public void testPublishConstraints() {
 
     }
@@ -179,6 +196,8 @@ public abstract class CommonResourceTest extends LdpTest {
             groups = {MUST},
             description = "LDP servers MUST support the HTTP GET Method for LDPRs")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-get-must")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testGetResource() throws URISyntaxException {
         assertTrue(supports(HttpMethod.GET), "HTTP GET is not listed in the Allow response header on HTTP OPTIONS requests for resource <" + getResourceUri() + ">");
         RestAssured
@@ -191,6 +210,8 @@ public abstract class CommonResourceTest extends LdpTest {
             description = "LDP servers MUST support the HTTP response headers "
                     + "defined in section 4.2.8 HTTP OPTIONS. ")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-get-options")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testGetResponseHeaders() throws URISyntaxException {
         ResponseSpecification expectResponse = RestAssured.expect();
         expectResponse.header(ALLOW, notNullValue());
@@ -214,6 +235,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "the identified resource with the entity representation "
                     + "in the body of the request.")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-put-replaceall")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testPutReplacesResource() throws URISyntaxException {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
     	
@@ -281,6 +304,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "constraints. This is a consequence of the requirement to "
                     + "enable simple creation and modification of LDPRs.")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-put-simpleupdate")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testAllowUpdateResources() throws URISyntaxException {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
 
@@ -318,6 +343,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "clients to modify, LDP servers MUST respond with a 4xx range "
                     + "status code (typically 409 Conflict)")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldprs-put-servermanagedprops")
+	@Status(status = Status.PENDING)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED)
     public void testPutReadOnlyProperties4xxStatus() {
 
     }
@@ -330,6 +357,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "information about which properties could not be persisted. The "
                     + "format of the 4xx response body is not constrained by LDP.")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldprs-put-servermanagedprops")
+	@Status(status = Status.PENDING)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED)
     public void test4xxErrorHasResponseBody() {
 
     }
@@ -342,6 +371,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "e.g. unknown content, LDP servers MUST respond with an "
                     + "appropriate 4xx range status code [HTTP11].")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldprs-put-failed")
+	@Status(status = Status.PENDING)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED)
     public void testPutPropertiesNotPersisted() {
 
     }
@@ -356,6 +387,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "servers expose these application-specific constraints as described "
                     + "in section 4.2.1 General.")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldprs-put-failed")
+	@Status(status = Status.PENDING)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED)
     public void testResponsePropertiesNotPersisted() {
 
     }
@@ -367,6 +400,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "client last retrieved its representation. LDP servers SHOULD require "
                     + "the HTTP If-Match header and HTTP ETags to detect collisions.")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-put-precond")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testPutRequiresIfMatch() throws URISyntaxException {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
 
@@ -399,7 +434,9 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "with status code 428 (Precondition Required) when the "
                     + "absence of a precondition is the only reason for rejecting "
                     + "the request [RFC6585].")
-    @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-put-precond")
+    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testConditionFailedStatusCode() throws URISyntaxException {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
 
@@ -433,7 +470,9 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "with status code 428 (Precondition Required) when the "
                     + "absence of a precondition is the only reason for rejecting "
                     + "the request [RFC6585].")
-    @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-put-precond")
+    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testPreconditionRequiredStatusCode() throws URISyntaxException {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
 
@@ -468,7 +507,9 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "with status code 428 (Precondition Required) when the "
                     + "absence of a precondition is the only reason for rejecting "
                     + "the request [RFC6585].")
-    @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-put-precond")
+    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond")
+	@Status(status = Status.PENDING)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED)
     public void testPutBadETag() throws URISyntaxException {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
 
@@ -496,6 +537,8 @@ public abstract class CommonResourceTest extends LdpTest {
             groups = {MUST},
             description = "LDP servers MUST support the HTTP HEAD method. ")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-head-must")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testHead() {
         assertTrue(supports(HttpMethod.HEAD), "HTTP HEAD is not listed in the Allow response header on HTTP OPTIONS requests for resource <" + getResourceUri() + ">");
         RestAssured.expect().statusCode(isSuccessful()).when().head(getResourceUri());
@@ -508,6 +551,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "OPTIONS requests, listing patch document media type(s) "
                     + "supported by the server. ")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-patch-acceptpatch")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testAcceptPatchHeader() throws URISyntaxException {
         skipIfMethodNotAllowed(HttpMethod.PATCH);
 
@@ -521,6 +566,8 @@ public abstract class CommonResourceTest extends LdpTest {
             groups = {MUST},
             description = "LDP servers MUST support the HTTP OPTIONS method. ")
     @Reference(uri =LdpTestSuite.SPEC_URI + "#ldpr-options-must")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testOptions() {
         RestAssured.expect().statusCode(isSuccessful()).when().options(getResourceUri());
     }
@@ -532,6 +579,8 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "by responding to a HTTP OPTIONS request on the LDPR’s URL "
                     + "with the HTTP Method tokens in the HTTP response header Allow. ")
     @Reference(uri =LdpTestSuite.SPEC_URI + "ldpr-options-allow")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testOptionsAllowHeader() throws URISyntaxException {
         URI uri = new URI(getResourceUri());
         RestAssured.expect().statusCode(isSuccessful()).header(ALLOW, notNullValue()).when().options(uri);

--- a/src/main/java/org/w3/ldp/testsuite/test/DirectContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/DirectContainerTest.java
@@ -19,13 +19,16 @@ import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.w3.ldp.testsuite.LdpTestSuite;
 import org.w3.ldp.testsuite.http.HttpMethod;
+import org.w3.ldp.testsuite.annotations.Implementation;
 import org.w3.ldp.testsuite.annotations.Reference;
+import org.w3.ldp.testsuite.annotations.Status;
 import org.w3.ldp.testsuite.mapper.RdfObjectMapper;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.response.Response;
+
 import org.w3.ldp.testsuite.vocab.LDP;
 
 public class DirectContainerTest extends CommonContainerTest {
@@ -59,6 +62,8 @@ public class DirectContainerTest extends CommonContainerTest {
                     + "(that is, rel='type') in all responses to requests made "
                     + "to the LDPC's HTTP Request-URI.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testHttpLinkHeader() throws URISyntaxException {
         Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
                 .expect().statusCode(HttpStatus.SC_OK).when()
@@ -74,6 +79,8 @@ public class DirectContainerTest extends CommonContainerTest {
                     + "as an LDPC's membership predicate if there is no obvious "
                     + "predicate from an application vocabulary to use.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpdc-mbrpred")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testUseMemberPredicate() throws URISyntaxException {
         Model containerModel = getAsModel(directContainer);
         Resource container = containerModel.getResource(directContainer);
@@ -90,6 +97,8 @@ public class DirectContainerTest extends CommonContainerTest {
                     + "constant-URI. Commonly the LDPC's URI is the membership-constant-URI,"
                     + " but LDP does not require this.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpdc-containres")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testMemberResourceTriple() throws URISyntaxException {
         Model containerModel = getAsModel(directContainer);
         Resource container = containerModel.getResource(directContainer);
@@ -106,6 +115,8 @@ public class DirectContainerTest extends CommonContainerTest {
                     + "such as ldp:hasMemberRelation or ldp:isMemberOfRelation, "
                     + "based on the membership triple pattern used by the container.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpdc-containtriples")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testMemberRelationOrIsMemberOfRelationTripleExists() throws URISyntaxException {
         Model containerModel = getAsModel(directContainer);
         Resource container = containerModel.getResource(directContainer);
@@ -126,6 +137,8 @@ public class DirectContainerTest extends CommonContainerTest {
                     + " triple, but LDP imposes no requirement to materialize such "
                     + "a triple in the LDP-DC representation.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpdc-indirectmbr-basic")
+	@Status(status = Status.PENDING)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED)
     public void testActAsIfInsertedContentRelationTripleExists() {
 
     }
@@ -138,6 +151,8 @@ public class DirectContainerTest extends CommonContainerTest {
                     + "membership triple MUST be consistent with any LDP-defined "
                     + "predicates it exposes.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpdc-post-createdmbr-member")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testPostResourceUpdatesTriples() throws URISyntaxException {
         skipIfMethodNotAllowed(HttpMethod.POST);
 
@@ -169,6 +184,8 @@ public class DirectContainerTest extends CommonContainerTest {
                     + "triple which was originally created by the LDP-DC is deleted, "
                     + "the LDPC server MUST also remove the corresponding membership triple.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpdc-del-contremovesmbrtriple")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testDeleteResourceUpdatesTriples() throws URISyntaxException {
         skipIfMethodNotAllowed(HttpMethod.POST);
 

--- a/src/main/java/org/w3/ldp/testsuite/test/IndirectContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/IndirectContainerTest.java
@@ -12,89 +12,93 @@ import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.w3.ldp.testsuite.LdpTestSuite;
+import org.w3.ldp.testsuite.annotations.Implementation;
 import org.w3.ldp.testsuite.annotations.Reference;
+import org.w3.ldp.testsuite.annotations.Status;
 
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.response.Response;
+
 import org.w3.ldp.testsuite.vocab.LDP;
 
 public class IndirectContainerTest extends CommonContainerTest {
     private String indirectContainer;
 
-    @Parameters("indirectContainer")
-    public IndirectContainerTest(@Optional String indirectContainer) {
-        this.indirectContainer = indirectContainer;
-    }
+	@Parameters("indirectContainer")
+	public IndirectContainerTest(@Optional String indirectContainer) {
+		this.indirectContainer = indirectContainer;
+	}
 
-    @BeforeClass(alwaysRun = true)
-    public void hasIndirectContainer() {
-        if (indirectContainer == null) {
-            throw new SkipException("No indirectContainer parameter provided in testng.xml. Skipping ldp:IndirectContainer tests.");
-        }
-    }
+	@BeforeClass(alwaysRun = true)
+	public void hasIndirectContainer() {
+		if (indirectContainer == null) {
+			throw new SkipException(
+					"No indirectContainer parameter provided in testng.xml. Skipping ldp:IndirectContainer tests.");
+		}
+	}
 
-    // TODO implement tests, signatures are from LDP spec
-    @Test(
-            groups = {MUST},
-            description = "LDP servers exposing LDPCs MUST advertise their "
-                    + "LDP support by exposing a HTTP Link header with a "
-                    + "target URI matching the type of container (see below) "
-                    + "the server supports, and a link relation type of type "
-                    + "(that is, rel='type') in all responses to requests made "
-                    + "to the LDPC's HTTP Request-URI.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr")
-    public void testContainerSupportsHttpLinkHeader() throws URISyntaxException {
-        Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
-                .expect().statusCode(HttpStatus.SC_OK).when()
-                .get(new URI(indirectContainer));
-        assertTrue(
-                hasLinkHeader(response, LDP.IndirectContainer.stringValue(), LINK_REL_TYPE),
-                "LDP DirectContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <" + LDP.IndirectContainer.stringValue() + "> and rel='type'");
-    }
+	// TODO implement tests, signatures are from LDP spec
+	@Test(groups = { MUST }, description = "LDP servers exposing LDPCs MUST advertise their "
+			+ "LDP support by exposing a HTTP Link header with a "
+			+ "target URI matching the type of container (see below) "
+			+ "the server supports, and a link relation type of type "
+			+ "(that is, rel='type') in all responses to requests made "
+			+ "to the LDPC's HTTP Request-URI.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr")
+	@Status(status = Status.APPROVED)
+	@Implementation(implementation = Implementation.IMPLEMENTED)
+	public void testContainerSupportsHttpLinkHeader() throws URISyntaxException {
+		Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
+				.expect().statusCode(HttpStatus.SC_OK).when()
+				.get(new URI(indirectContainer));
+		assertTrue(
+				hasLinkHeader(response, LDP.IndirectContainer.stringValue(),
+						LINK_REL_TYPE),
+				"LDP DirectContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <"
+						+ LDP.IndirectContainer.stringValue()
+						+ "> and rel='type'");
+	}
 
-    @Test(
-            groups = {MUST},
-            enabled = false,
-            description = "Each LDP Indirect Container MUST also be a conforming "
-                    + "LDP Direct Container in section 5.4 Direct along "
-                    + "the following restrictions.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpic-are-ldpcs")
-    public void testCreateIndirectContainer() {
+	@Test(groups = { MUST }, enabled = false, description = "Each LDP Indirect Container MUST also be a conforming "
+			+ "LDP Direct Container in section 5.4 Direct along "
+			+ "the following restrictions.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpic-are-ldpcs")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	public void testCreateIndirectContainer() {
 
-    }
+	}
 
-    @Test(
-            groups = {MUST},
-            enabled = false,
-            description = "LDP Indirect Containers MUST contain exactly one "
-                    + "triple whose subject is the LDPC URI, whose predicate "
-                    + "is ldp:insertedContentRelation, and whose object ICR "
-                    + "describes how the member-derived-URI in the container's "
-                    + "membership triples is chosen.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpic-indirectmbr")
-    public void testContainsLdpcUri() {
+	@Test(groups = { MUST }, enabled = false, description = "LDP Indirect Containers MUST contain exactly one "
+			+ "triple whose subject is the LDPC URI, whose predicate "
+			+ "is ldp:insertedContentRelation, and whose object ICR "
+			+ "describes how the member-derived-URI in the container's "
+			+ "membership triples is chosen.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpic-indirectmbr")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	public void testContainsLdpcUri() {
 
-    }
+	}
 
-    @Test(
-            groups = {MUST},
-            enabled = false,
-            description = "LDPCs whose ldp:insertedContentRelation triple has an "
-                    + "object other than ldp:MemberSubject and that create new "
-                    + "resources MUST add a triple to the container whose subject is "
-                    + "the container's URI, whose predicate is ldp:contains, and whose "
-                    + "object is the newly created resource's URI (which will be "
-                    + "different from the member-derived URI in this case). This "
-                    + "ldp:contains triple can be the only link from the container to the "
-                    + "newly created resource in certain cases.")
-    @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpic-post-indirectmbrrel")
-    public void testPostResource() {
+	@Test(groups = { MUST }, enabled = false, description = "LDPCs whose ldp:insertedContentRelation triple has an "
+			+ "object other than ldp:MemberSubject and that create new "
+			+ "resources MUST add a triple to the container whose subject is "
+			+ "the container's URI, whose predicate is ldp:contains, and whose "
+			+ "object is the newly created resource's URI (which will be "
+			+ "different from the member-derived URI in this case). This "
+			+ "ldp:contains triple can be the only link from the container to the "
+			+ "newly created resource in certain cases.")
+	@Reference(uri = LdpTestSuite.SPEC_URI + "#ldpic-post-indirectmbrrel")
+	@Status(status = Status.PENDING)
+	@Implementation(implementation = Implementation.NOT_IMPLEMENTED)
+	public void testPostResource() {
 
-    }
+	}
 
-    @Override
-    protected String getResourceUri() {
-        return indirectContainer;
-    }
+	@Override
+	protected String getResourceUri() {
+		return indirectContainer;
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
@@ -1,14 +1,16 @@
 package org.w3.ldp.testsuite.test;
 
 import com.hp.hpl.jena.rdf.model.Model;
-
 import com.jayway.restassured.RestAssured;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.hamcrest.CoreMatchers;
 import org.testng.annotations.Test;
 import org.w3.ldp.testsuite.LdpTestSuite;
+import org.w3.ldp.testsuite.annotations.Implementation;
 import org.w3.ldp.testsuite.annotations.Reference;
+import org.w3.ldp.testsuite.annotations.Status;
 import org.w3.ldp.testsuite.mapper.RdfObjectMapper;
 import org.w3.ldp.testsuite.matcher.HeaderMatchers;
 
@@ -27,6 +29,8 @@ public abstract class NonRDFSourceTest extends CommonResourceTest {
                     "representations (LDP-NRs) for creation of any kind of " +
                     "resource, for example binary resources.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#dfn-ldp-server")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testPostResource() throws URISyntaxException, IOException {
         // Make sure we can post binary resources
         RestAssured

--- a/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
@@ -9,7 +9,9 @@ import java.net.URISyntaxException;
 import org.apache.http.HttpStatus;
 import org.testng.annotations.Test;
 import org.w3.ldp.testsuite.LdpTestSuite;
+import org.w3.ldp.testsuite.annotations.Implementation;
 import org.w3.ldp.testsuite.annotations.Reference;
+import org.w3.ldp.testsuite.annotations.Status;
 import org.w3.ldp.testsuite.exception.SkipClientTestException;
 import org.w3.ldp.testsuite.exception.SkipNotTestableException;
 import org.w3.ldp.testsuite.mapper.RdfObjectMapper;
@@ -29,6 +31,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
                     + "for LDP-RSs. The HTTP Request-URI of the LDP-RS is "
                     + "typically the subject of most triples in the response.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldprs-gen-rdf")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testGetResource() throws URISyntaxException {
         // Make sure we can get the resource itself and the response is
         // valid RDF. Turtle is a required media type, so this request
@@ -45,6 +49,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
                     + " much more useful to client applications that don’t "
                     + "support inferencing.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldprs-gen-atleast1rdftype")
+    @Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testContainsRdfType() throws URISyntaxException {
         Model containerModel = getAsModel(getResourceUri());
         Resource r = containerModel.getResource(getResourceUri());
@@ -58,6 +64,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
                     + "to this general rule, some specific cases are covered by "
                     + "other conformance rules.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldprs-gen-reusevocab")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED, manual = true)
     public void testReUseVocabularies() {
         throw new SkipNotTestableException();
     }
@@ -68,6 +76,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
                     + "as Dublin Core [DC-TERMS], RDF [rdf11-concepts] and RDF "
                     + "Schema [rdf-schema], whenever possible.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldprs-gen-reusevocabsuchas")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED, manual = true)
     public void testUseStandardVocabularies() throws URISyntaxException {
         throw new SkipNotTestableException();
     }
@@ -78,6 +88,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
                     + "or domain, LDP clients MUST assume that any LDP-RS can "
                     + "have multiple values for rdf:type.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldp-cli-multitype")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED, clientOnly = true)
     public void testAllowMultipleRdfTypes() {
         throw new SkipClientTestException();
     }
@@ -89,6 +101,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
                     + "that the rdf:type values of a given LDP-RS can "
                     + "change over time.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-cli-typeschange")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED, clientOnly = true)
     public void testChangeRdfTypeValue() {
         throw new SkipClientTestException();
     }
@@ -103,6 +117,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
                     + "that are used in the state of any one LDP-RS is not limited "
                     + "to any pre-defined set.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-cli-openpreds")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED, clientOnly = true)
     public void testServerOpen() {
         throw new SkipClientTestException();
     }
@@ -116,6 +132,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
                     + "content defined by LDP must be explicitly represented, unless noted "
                     + "otherwise within this document.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldprs-gen-noinferencing")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED, isTestable = false, manual = true)
     public void testRestrictClientInference() {
         throw new SkipNotTestableException();
     }
@@ -129,6 +147,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
                     + "HTTP PATCH instead of HTTP PUT for update avoids this "
                     + "burden for clients [RFC5789]. ")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-cli-preservetriples")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED, isTestable = false, manual = true)
     public void testGetResourcePreservesTriples() throws URISyntaxException {
         throw new SkipNotTestableException();
     }
@@ -139,6 +159,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
                     + "formed by an LDP server that ignores hints, including "
                     + "LDP-defined hints.")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldpr-cli-hints-ignorable")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.NOT_IMPLEMENTED, isTestable = false, manual = true)
     public void testAllowResponsesFromServer() {
         throw new SkipNotTestableException();
     }
@@ -148,6 +170,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
             description = "LDP servers MUST provide a text/turtle representation "
                     + "of the requested LDP-RS [turtle].")
     @Reference(uri = LdpTestSuite.SPEC_URI + "#ldprs-get-turtle")
+	@Status(status = Status.APPROVED)
+    @Implementation(implementation = Implementation.IMPLEMENTED)
     public void testGetResourceTurtle() throws URISyntaxException {
         RestAssured.given().header(ACCEPT, TEXT_TURTLE)
                 .expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)

--- a/src/main/resources/testCaseStyle.css
+++ b/src/main/resources/testCaseStyle.css
@@ -1,0 +1,43 @@
+@CHARSET "ISO-8859-1";
+
+h1 {
+	text-align: center
+}
+
+th {
+	border: 1px solid black;
+	padding: 10px
+}
+
+td,tr {
+	border: 1px solid black;
+	padding: 20px;
+	border-collapse: collapse
+}
+
+.annotation {
+	border-collapse: collapse;
+	border: 1px solid black;
+	margin-left: +3em;
+	border: 1px solid black
+}
+
+.summary {
+	border: 1px solid black;
+	padding: 20px;
+	border-collapse: collapse;
+	border: 1px solid black;
+	margin-left: +5em
+}
+
+.totop {
+	font-size: 80%;
+	text-align: center;
+	border-bottom: 2px solid
+}
+
+.totest {
+	font-size: 80%;
+	text-align: center;
+	border-bottom: 2px dashed
+}


### PR DESCRIPTION
The new annotations, Status and Implementation, are applied to the test
suite.

The test case reporter can run by itself, and can be found in the
report directory after running.

Change-Id: Ic55e79044533ffa86f968349c42d14a4c1ec4ca3
Signed-off-by: ttsanton ttsanton@us.ibm.com
