### PR TITLE
remove unnecessary calls to new URI()

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/BasicContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/BasicContainerTest.java
@@ -2,9 +2,6 @@ package org.w3.ldp.testsuite.test;
 
 import static org.testng.Assert.assertTrue;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import org.apache.http.HttpStatus;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
@@ -12,17 +9,16 @@ import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.w3.ldp.testsuite.LdpTestSuite;
+import org.w3.ldp.testsuite.annotations.SpecTest;
+import org.w3.ldp.testsuite.annotations.SpecTest.METHOD;
+import org.w3.ldp.testsuite.annotations.SpecTest.STATUS;
+import org.w3.ldp.testsuite.vocab.LDP;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.vocabulary.RDF;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.response.Response;
-
-import org.w3.ldp.testsuite.annotations.SpecTest;
-import org.w3.ldp.testsuite.annotations.SpecTest.METHOD;
-import org.w3.ldp.testsuite.annotations.SpecTest.STATUS;
-import org.w3.ldp.testsuite.vocab.LDP;
 
 public class BasicContainerTest extends CommonContainerTest {
 
@@ -53,10 +49,10 @@ public class BasicContainerTest extends CommonContainerTest {
 			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr", 
 			testMethod = METHOD.AUTOMATED,
 			approval   = STATUS.WG_APPROVED)
-	public void testContainerSupportsHttpLinkHeader() throws URISyntaxException {
+	public void testContainerSupportsHttpLinkHeader() {
 		Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
 				.expect().statusCode(HttpStatus.SC_OK).when()
-				.get(new URI(basicContainer));
+				.get(basicContainer);
 		assertTrue(
 				hasLinkHeader(response, LDP.BasicContainer.stringValue(),
 						LINK_REL_TYPE),
@@ -73,7 +69,7 @@ public class BasicContainerTest extends CommonContainerTest {
 			specRefUri = LdpTestSuite.SPEC_URI + "#ldpbc-are-ldpcs", 
 			testMethod = METHOD.AUTOMATED,
 			approval   = STATUS.WG_APPROVED)
-	public void testContainerTypeIsBasicContainer() throws URISyntaxException {
+	public void testContainerTypeIsBasicContainer() {
 		// FIXME: We're just testing the RDF type here. We're not really testing
 		// the requirement.
 		Model containerModel = getAsModel(basicContainer);

--- a/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
@@ -51,10 +51,10 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-create", 
 			testMethod = METHOD.AUTOMATED,
 			approval   = STATUS.WG_APPROVED)
-	public void testPutToCreate() throws URISyntaxException {
+	public void testPutToCreate() {
 		String location = putToCreate();
 		RestAssured.expect().statusCode(isSuccessful()).when()
-				.delete(new URI(location));
+				.delete(location);
 	}
 
 	@Test(
@@ -81,7 +81,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-nordfcontainertypes", 
 			testMethod = METHOD.AUTOMATED,
 			approval   = STATUS.WG_APPROVED)
-	public void testNoRdfBagSeqOrList() throws URISyntaxException {
+	public void testNoRdfBagSeqOrList() {
 		Model containerModel = getAsModel(getResourceUri());
 		assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.Bag)
 				.hasNext(), "LDPC representations should not use rdf:Bag");
@@ -139,7 +139,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
 				.body(model, new RdfObjectMapper()).expect()
 				.statusCode(HttpStatus.SC_CREATED).when()
-				.post(new URI(getResourceUri()));
+				.post(getResourceUri());
 
 		String location = postResponse.getHeader(LOCATION);
 		assertNotNull(location, MSG_LOC_NOTFOUND);
@@ -165,7 +165,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
 				.body(model, new RdfObjectMapper()).expect()
 				.statusCode(HttpStatus.SC_CREATED).when()
-				.post(new URI(getResourceUri()));
+				.post(getResourceUri());
 
 		String location = postResponse.getHeader(LOCATION);
 		assertNotNull(location, MSG_LOC_NOTFOUND);
@@ -182,8 +182,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 						+ "> does not have a containment triple for newly created resource <"
 						+ location + ">.");
 
-		RestAssured.expect().statusCode(isSuccessful()).when()
-				.delete(new URI(location));
+		RestAssured.expect().statusCode(isSuccessful()).when().delete(location);
 	}
 
 	@Test(
@@ -211,20 +210,19 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-turtle", 
 			testMethod = METHOD.AUTOMATED,
 			approval   = STATUS.WG_APPROVED)
-	public void testAcceptTurtle() throws URISyntaxException {
+	public void testAcceptTurtle() {
 		skipIfMethodNotAllowed(HttpMethod.POST);
 
 		Model model = postContent();
 		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
 				.body(model, new RdfObjectMapper()).expect()
 				.statusCode(HttpStatus.SC_CREATED).when()
-				.post(new URI(getResourceUri()));
+				.post(getResourceUri());
 
 		// Delete the resource to clean up.
 		String location = postResponse.getHeader(LOCATION);
 		if (location != null) {
-			RestAssured.expect().statusCode(isSuccessful()).when()
-					.delete(new URI(location));
+			RestAssured.expect().statusCode(isSuccessful()).when().delete(location);
 		}
 	}
 
@@ -267,7 +265,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
 				.body(requestModel, new RdfObjectMapper(getResourceUri()))
 				.expect().statusCode(HttpStatus.SC_CREATED).when()
-				.post(new URI(getResourceUri()));
+				.post(getResourceUri());
 
 		String location = postResponse.getHeader(LOCATION);
 		assertNotNull(location, MSG_LOC_NOTFOUND);
@@ -286,8 +284,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 						+ "> does not have the dcterms:identifier as the resource POSTed using the null relative URI.");
 
 		// Delete the resource to clean up.
-		RestAssured.expect().statusCode(isSuccessful()).when()
-				.delete(new URI(location));
+		RestAssured.expect().statusCode(isSuccessful()).when().delete(location);
 	}
 
 	@Test(
@@ -328,13 +325,12 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
 				.body(requestModel, new RdfObjectMapper()).expect()
 				.statusCode(HttpStatus.SC_CREATED).when()
-				.post(new URI(getResourceUri()));
+				.post(getResourceUri());
 
 		// Delete the resource to clean up.
 		String location = postResponse.getHeader(LOCATION);
 		if (location != null) {
-			RestAssured.expect().statusCode(isSuccessful()).when()
-					.delete(new URI(location));
+			RestAssured.expect().statusCode(isSuccessful()).when().delete(location);
 		}
 
 	}
@@ -400,12 +396,12 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-acceptposthdr", 
 			testMethod = METHOD.AUTOMATED,
 			approval   = STATUS.WG_APPROVED)
-	public void testAcceptPostResponseHeader() throws URISyntaxException {
+	public void testAcceptPostResponseHeader() {
 		skipIfMethodNotAllowed(HttpMethod.POST);
 
 		Response optionsResponse = RestAssured.expect()
 				.statusCode(isSuccessful()).when()
-				.options(new URI(getResourceUri()));
+				.options(getResourceUri());
 		assertNotNull(
 				optionsResponse.getHeader(ACCEPT_POST),
 				"The HTTP OPTIONS response on container <"
@@ -455,16 +451,15 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-put-create", 
 			testMethod = METHOD.AUTOMATED,
 			approval   = STATUS.WG_APPROVED)
-	public void testRestrictPutReUseUri() throws URISyntaxException {
+	public void testRestrictPutReUseUri() {
 		String location = putToCreate();
-		URI uri = new URI(location);
 
 		// Delete the resource.
     	RestAssured
     		.expect()
     			.statusCode(isSuccessful())
     		.when()
-    			.delete(uri);
+    			.delete(location);
 
 		// Try to put to the same URI again. It should fail.
     	Model content = postContent();
@@ -475,7 +470,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
     		.expect()
     			.statusCode(not(isSuccessful()))
     		.when()
-    			.put(uri);
+    			.put(location);
 	}
 
 	@Test(
@@ -494,7 +489,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 		Response postResponse = RestAssured.given().contentType(TEXT_TURTLE)
 				.body(model, new RdfObjectMapper()).expect()
 				.statusCode(HttpStatus.SC_CREATED).when()
-				.post(new URI(getResourceUri()));
+				.post(getResourceUri());
 
 		// POST support is optional. Only test delete if the POST succeeded.
 		if (postResponse.getStatusCode() != HttpStatus.SC_CREATED) {
@@ -509,7 +504,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 
 		// Delete the resource
 		RestAssured.expect().statusCode(isSuccessful()).when()
-				.delete(new URI(location));
+				.delete(location);
 
 		// Test the membership triple
 		Model containerModel = getAsModel(getResourceUri());
@@ -601,14 +596,13 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 		// resource.
 		// Delete the resource to make sure the server doesn't reuse the URI
 		// below.
-		RestAssured.expect().statusCode(isSuccessful()).when()
-				.delete(new URI(loc1));
+		RestAssured.expect().statusCode(isSuccessful()).when().delete(loc1);
 
 		String loc2 = post(content, slug);
 		assertNotEquals(loc1, loc2, "Server reused URIs for POSTed resources.");
 	}
 
-	private String post(Model content, String slug) throws URISyntaxException {
+	private String post(Model content, String slug) {
 		RequestSpecification spec = RestAssured.given()
 				.contentType(TEXT_TURTLE);
 		if (slug != null) {
@@ -616,7 +610,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 		}
 		Response post = spec.body(content, new RdfObjectMapper()).expect()
 				.statusCode(HttpStatus.SC_CREATED).when()
-				.post(new URI(getResourceUri()));
+				.post(getResourceUri());
 		String location = post.getHeader(LOCATION);
 		assertNotNull(location, MSG_LOC_NOTFOUND);
 

--- a/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.testng.Assert.assertTrue;
 import static org.w3.ldp.testsuite.matcher.HttpStatusSuccessMatcher.isSuccessful;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashSet;
 
@@ -43,12 +42,12 @@ public abstract class CommonResourceTest extends LdpTest {
     protected abstract String getResourceUri();
 
     @BeforeClass(alwaysRun = true)
-    public void determineOptions() throws URISyntaxException {
+    public void determineOptions() {
         String uri = getResourceUri();
 
         if (uri != null) {
             // Use HTTP OPTIONS, which MUST be supported by LDP servers, to determine what methods are supported on this container.
-            Response optionsResponse = RestAssured.options(new URI(uri));
+            Response optionsResponse = RestAssured.options(uri);
             String allow = optionsResponse.header(ALLOW);
             if (allow != null) {
                 String[] methods = allow.split("\\s*,\\s*");
@@ -67,9 +66,9 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-http", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_EXTENSION)
-    public void testIsHttp11Server() throws URISyntaxException {
+    public void testIsHttp11Server() {
     	// TODO: Consider a more extensive test for HTTP/1.1
-        RestAssured.expect().statusLine(containsString("HTTP/1.1")).when().head(new URI(getResourceUri()));
+        RestAssured.expect().statusLine(containsString("HTTP/1.1")).when().head(getResourceUri());
     }
     
     @Test(
@@ -109,11 +108,11 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-etags", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testETagHeadersGet() throws URISyntaxException {
+    public void testETagHeadersGet() {
         // GET requests
         RestAssured.given().header(ACCEPT, TEXT_TURTLE)
                 .expect().statusCode(isSuccessful()).header(ETAG, notNullValue())
-                .when().get(new URI(getResourceUri()));
+                .when().get(getResourceUri());
     }
 
     @Test(
@@ -125,11 +124,11 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-etags", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testETagHeadersHead() throws URISyntaxException {
+    public void testETagHeadersHead() {
         // GET requests
         RestAssured.given().header(ACCEPT, TEXT_TURTLE)
                 .expect().statusCode(isSuccessful()).header(ETAG, notNullValue())
-                .when().head(new URI(getResourceUri()));
+                .when().head(getResourceUri());
     }
 
     @Test(
@@ -144,10 +143,10 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-linktypehdr", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testLdpLinkHeader() throws URISyntaxException {
+    public void testLdpLinkHeader() {
         Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
                 .expect().statusCode(isSuccessful())
-                .when().get(new URI(getResourceUri()));
+                .when().get(getResourceUri());
         assertTrue(
                 hasLinkHeader(response, LDP.Resource.stringValue(), LINK_REL_TYPE),
                 "4.2.1.4 LDP servers exposing LDPRs must advertise their LDP support by exposing a HTTP Link header "
@@ -168,13 +167,13 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-defbaseuri", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testRelativeUriResolutionPut() throws URISyntaxException {
+    public void testRelativeUriResolutionPut() {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
 
     	String resourceUri = getResourceUri();
     	Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
     			.expect().statusCode(isSuccessful()).header(ETAG, notNullValue())
-    			.when().get(new URI(resourceUri));
+    			.when().get(resourceUri);
     	
     	String eTag = response.getHeader(ETAG);
     	Model model = response.as(Model.class, new RdfObjectMapper("")); // relative URI
@@ -187,12 +186,12 @@ public abstract class CommonResourceTest extends LdpTest {
                 .given().contentType(TEXT_TURTLE).header(IF_MATCH, eTag)
                 	.body(model, new RdfObjectMapper("")) // relative URI
                 .expect().statusCode(isSuccessful())
-                .when().put(new URI(resourceUri));
+                .when().put(resourceUri);
     	
     	// Get the resource again to verify its content.
     	model = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
     			.expect().statusCode(isSuccessful())
-    			.when().get(new URI(resourceUri)).as(Model.class, new RdfObjectMapper(resourceUri));
+    			.when().get(resourceUri).as(Model.class, new RdfObjectMapper(resourceUri));
     	
     	// Verify the change.
     	verifyUpdatedResource(model.getResource(resourceUri));
@@ -220,11 +219,11 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-get-must", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testGetResource() throws URISyntaxException {
+    public void testGetResource() {
         assertTrue(supports(HttpMethod.GET), "HTTP GET is not listed in the Allow response header on HTTP OPTIONS requests for resource <" + getResourceUri() + ">");
         RestAssured
                 .expect().statusCode(isSuccessful())
-                .when().get(new URI(getResourceUri()));
+                .when().get(getResourceUri());
     }
 
     @Test(
@@ -235,7 +234,7 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-get-options", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testGetResponseHeaders() throws URISyntaxException {
+    public void testGetResponseHeaders() {
         ResponseSpecification expectResponse = RestAssured.expect();
         expectResponse.header(ALLOW, notNullValue());
 
@@ -248,7 +247,7 @@ public abstract class CommonResourceTest extends LdpTest {
             expectResponse.header(ACCEPT_POST, notNullValue());
         }
 
-        expectResponse.when().get(new URI(getResourceUri()));
+        expectResponse.when().get(getResourceUri());
     }
 
     @Test(
@@ -261,7 +260,7 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-replaceall", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testPutReplacesResource() throws URISyntaxException {
+    public void testPutReplacesResource() {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
     	
     	if (restrictionsOnContent()) {
@@ -272,7 +271,7 @@ public abstract class CommonResourceTest extends LdpTest {
     	String resourceUri = getResourceUri();
     	Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
     			.expect().statusCode(isSuccessful()).header(ETAG, notNullValue())
-    			.when().get(new URI(resourceUri));
+    			.when().get(resourceUri);
     	
     	String eTag = response.getHeader(ETAG);
     	Model originalModel = response.as(Model.class, new RdfObjectMapper(resourceUri));
@@ -286,12 +285,12 @@ public abstract class CommonResourceTest extends LdpTest {
                 .given().contentType(TEXT_TURTLE).header(IF_MATCH, eTag)
                 	.body(differentContent, new RdfObjectMapper(resourceUri)) // relative URI
                 .expect().statusCode(isSuccessful())
-                .when().put(new URI(resourceUri));
+                .when().put(resourceUri);
     	
     	// Get the resource again to see what's there.
     	response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
     			.expect().statusCode(isSuccessful()).header(ETAG, notNullValue())
-    			.when().get(new URI(resourceUri));
+    			.when().get(resourceUri);
     	eTag = response.getHeader(ETAG);
     	Model updatedModel = response.as(Model.class, new RdfObjectMapper(resourceUri));
     	
@@ -318,7 +317,7 @@ public abstract class CommonResourceTest extends LdpTest {
                 .given().contentType(TEXT_TURTLE).header(IF_MATCH, eTag)
                 	.body(originalModel, new RdfObjectMapper(resourceUri)) // relative URI
                 .expect().statusCode(isSuccessful())
-                .when().put(new URI(resourceUri));
+                .when().put(resourceUri);
     }
 
     @Test(
@@ -331,13 +330,13 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-simpleupdate", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testAllowUpdateResources() throws URISyntaxException {
+    public void testAllowUpdateResources() {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
 
     	String resourceUri = getResourceUri();
     	Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
     			.expect().statusCode(isSuccessful()).header(ETAG, notNullValue())
-    			.when().get(new URI(resourceUri));
+    			.when().get(resourceUri);
     	
     	String eTag = response.getHeader(ETAG);
     	Model model = response.as(Model.class, new RdfObjectMapper(resourceUri));
@@ -349,12 +348,12 @@ public abstract class CommonResourceTest extends LdpTest {
                 .given().contentType(TEXT_TURTLE).header(IF_MATCH, eTag)
                 	.body(model, new RdfObjectMapper(resourceUri))
                 .expect().statusCode(isSuccessful())
-                .when().put(new URI(resourceUri));
+                .when().put(resourceUri);
     	
     	// Get the resource again to verify its content.
     	model = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
     			.expect().statusCode(isSuccessful())
-    			.when().get(new URI(resourceUri)).as(Model.class, new RdfObjectMapper(resourceUri));
+    			.when().get(resourceUri).as(Model.class, new RdfObjectMapper(resourceUri));
     	
     	// Verify the change.
     	verifyUpdatedResource(model.getResource(resourceUri));
@@ -443,7 +442,7 @@ public abstract class CommonResourceTest extends LdpTest {
     				.statusCode(isSuccessful())
     				.header(ETAG, notNullValue())
     			.when()
-    				.get(new URI(resourceUri)).as(Model.class, new RdfObjectMapper(resourceUri));
+    				.get(resourceUri).as(Model.class, new RdfObjectMapper(resourceUri));
 
     	RestAssured
                 .given()
@@ -452,7 +451,7 @@ public abstract class CommonResourceTest extends LdpTest {
                 .expect()
                 	.statusCode(not(isSuccessful()))
                 .when()
-                	.put(new URI(resourceUri));
+                	.put(resourceUri);
     }
 
     @Test(
@@ -468,7 +467,7 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testConditionFailedStatusCode() throws URISyntaxException {
+    public void testConditionFailedStatusCode() {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
 
     	String resourceUri = getResourceUri();
@@ -505,7 +504,7 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testPreconditionRequiredStatusCode() throws URISyntaxException {
+    public void testPreconditionRequiredStatusCode() {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
 
     	String resourceUri = getResourceUri();
@@ -516,7 +515,7 @@ public abstract class CommonResourceTest extends LdpTest {
     				.statusCode(isSuccessful())
     				.header(ETAG, notNullValue())
     			.when()
-    				.get(new URI(resourceUri)).as(Model.class, new RdfObjectMapper(resourceUri));
+    				.get(resourceUri).as(Model.class, new RdfObjectMapper(resourceUri));
 
     	RestAssured
                 .given()
@@ -525,7 +524,7 @@ public abstract class CommonResourceTest extends LdpTest {
                 .expect()
                 	.statusCode(428)
                 .when()
-                	.put(new URI(resourceUri));
+                	.put(resourceUri);
     }
 
     @Test(
@@ -543,7 +542,7 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond", 
     		testMethod = METHOD.NOT_IMPLEMENTED,
     		approval   = STATUS.WG_APPROVED)
-    public void testPutBadETag() throws URISyntaxException {
+    public void testPutBadETag() {
     	skipIfMethodNotAllowed(HttpMethod.PUT);
 
     	String resourceUri = getResourceUri();
@@ -553,7 +552,7 @@ public abstract class CommonResourceTest extends LdpTest {
     			.expect()
     				.statusCode(isSuccessful()).header(ETAG, notNullValue())
     			.when()
-    				.get(new URI(resourceUri)).as(Model.class, new RdfObjectMapper(resourceUri));
+    				.get(resourceUri).as(Model.class, new RdfObjectMapper(resourceUri));
 
     	RestAssured
                 .given().contentType(TEXT_TURTLE)
@@ -562,7 +561,7 @@ public abstract class CommonResourceTest extends LdpTest {
                 .expect()
                 	.statusCode(HttpStatus.SC_PRECONDITION_FAILED)
                 .when()
-                	.put(new URI(resourceUri));
+                	.put(resourceUri);
     }
 
     @Test(
@@ -588,12 +587,12 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-patch-acceptpatch", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testAcceptPatchHeader() throws URISyntaxException {
+    public void testAcceptPatchHeader() {
         skipIfMethodNotAllowed(HttpMethod.PATCH);
 
         RestAssured
                 .expect().statusCode(isSuccessful()).header(ACCEPT_PATCH, notNullValue())
-                .when().options(new URI(getResourceUri()));
+                .when().options(getResourceUri());
     }
 
     @Test(
@@ -618,9 +617,9 @@ public abstract class CommonResourceTest extends LdpTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "ldpr-options-allow",
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testOptionsAllowHeader() throws URISyntaxException {
-        URI uri = new URI(getResourceUri());
-        RestAssured.expect().statusCode(isSuccessful()).header(ALLOW, notNullValue()).when().options(uri);
+    public void testOptionsAllowHeader() {
+        RestAssured.expect().statusCode(isSuccessful()).header(ALLOW, notNullValue())
+        	.when().options(getResourceUri());
     }
 
     protected boolean supports(HttpMethod method) {

--- a/src/main/java/org/w3/ldp/testsuite/test/DirectContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/DirectContainerTest.java
@@ -8,7 +8,6 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.w3.ldp.testsuite.matcher.HttpStatusSuccessMatcher.isSuccessful;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.apache.http.HttpStatus;
@@ -23,13 +22,12 @@ import org.w3.ldp.testsuite.annotations.SpecTest.METHOD;
 import org.w3.ldp.testsuite.annotations.SpecTest.STATUS;
 import org.w3.ldp.testsuite.http.HttpMethod;
 import org.w3.ldp.testsuite.mapper.RdfObjectMapper;
+import org.w3.ldp.testsuite.vocab.LDP;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.response.Response;
-
-import org.w3.ldp.testsuite.vocab.LDP;
 
 public class DirectContainerTest extends CommonContainerTest {
     private String directContainer;
@@ -65,10 +63,10 @@ public class DirectContainerTest extends CommonContainerTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testHttpLinkHeader() throws URISyntaxException {
+    public void testHttpLinkHeader() {
         Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
                 .expect().statusCode(HttpStatus.SC_OK).when()
-                .get(new URI(directContainer));
+                .get(directContainer);
         assertTrue(
                 hasLinkHeader(response, LDP.DirectContainer.stringValue(), LINK_REL_TYPE),
                 "LDP DirectContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <" + LDP.DirectContainer.stringValue() + "> and rel='type'");
@@ -159,13 +157,13 @@ public class DirectContainerTest extends CommonContainerTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-post-createdmbr-member", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testPostResourceUpdatesTriples() throws URISyntaxException {
+    public void testPostResourceUpdatesTriples() {
         skipIfMethodNotAllowed(HttpMethod.POST);
 
         Model model = postContent();
         Response postResponse = RestAssured.given().contentType(TEXT_TURTLE).body(model, new RdfObjectMapper())
                 .expect().statusCode(HttpStatus.SC_CREATED).header(LOCATION, notNullValue())
-                .when().post(new URI(directContainer));
+                .when().post(directContainer);
 
         String location = postResponse.getHeader(LOCATION);
         Model containerModel = getAsModel(directContainer);
@@ -181,7 +179,7 @@ public class DirectContainerTest extends CommonContainerTest {
         }
 
         // Delete the resource to clean up.
-        RestAssured.expect().statusCode(isSuccessful()).when().delete(new URI(location));
+        RestAssured.expect().statusCode(isSuccessful()).when().delete(location);
     }
 
     @Test(
@@ -193,13 +191,13 @@ public class DirectContainerTest extends CommonContainerTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-del-contremovesmbrtriple", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testDeleteResourceUpdatesTriples() throws URISyntaxException {
+    public void testDeleteResourceUpdatesTriples() {
         skipIfMethodNotAllowed(HttpMethod.POST);
 
         Model model = postContent();
         Response postResponse = RestAssured.given().contentType(TEXT_TURTLE).body(model, new RdfObjectMapper())
                 .expect().statusCode(HttpStatus.SC_CREATED).header(LOCATION, notNullValue())
-                .when().post(new URI(directContainer));
+                .when().post(directContainer);
 
         String location = postResponse.getHeader(LOCATION);
 
@@ -234,7 +232,7 @@ public class DirectContainerTest extends CommonContainerTest {
         }
 
         // Delete the resource
-        RestAssured.expect().statusCode(isSuccessful()).when().delete(new URI(location));
+        RestAssured.expect().statusCode(isSuccessful()).when().delete(location);
 
         // Get the updated membership resource
         membershipResourceModel = getAsModel(membershipResource.getURI());

--- a/src/main/java/org/w3/ldp/testsuite/test/IndirectContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/IndirectContainerTest.java
@@ -2,9 +2,6 @@ package org.w3.ldp.testsuite.test;
 
 import static org.testng.Assert.assertTrue;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import org.apache.http.HttpStatus;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
@@ -12,14 +9,13 @@ import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.w3.ldp.testsuite.LdpTestSuite;
-
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
-
 import org.w3.ldp.testsuite.annotations.SpecTest;
 import org.w3.ldp.testsuite.annotations.SpecTest.METHOD;
 import org.w3.ldp.testsuite.annotations.SpecTest.STATUS;
 import org.w3.ldp.testsuite.vocab.LDP;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.response.Response;
 
 public class IndirectContainerTest extends CommonContainerTest {
     private String indirectContainer;
@@ -50,10 +46,10 @@ public class IndirectContainerTest extends CommonContainerTest {
 			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr", 
 			testMethod = METHOD.AUTOMATED,
 			approval   = STATUS.WG_APPROVED)
-	public void testContainerSupportsHttpLinkHeader() throws URISyntaxException {
+	public void testContainerSupportsHttpLinkHeader() {
 		Response response = RestAssured.given().header(ACCEPT, TEXT_TURTLE)
 				.expect().statusCode(HttpStatus.SC_OK).when()
-				.get(new URI(indirectContainer));
+				.get(indirectContainer);
 		assertTrue(
 				hasLinkHeader(response, LDP.IndirectContainer.stringValue(),
 						LINK_REL_TYPE),

--- a/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
@@ -1,7 +1,5 @@
 package org.w3.ldp.testsuite.test;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 
 import org.apache.http.HttpStatus;
@@ -83,16 +81,15 @@ public abstract class LdpTest implements HttpHeaders, MediaTypes {
         return false;
     }
 
-    public Model getAsModel(String uri) throws URISyntaxException {
+    public Model getAsModel(String uri) {
         return getResourceAsModel(uri, TEXT_TURTLE);
     }
 
-    public Model getResourceAsModel(String uri, String mediaType)
-            throws URISyntaxException {
+    public Model getResourceAsModel(String uri, String mediaType) {
         return RestAssured
                 .given().header(ACCEPT, mediaType)
                 .expect().statusCode(HttpStatus.SC_OK)
-                .when().get(new URI(uri)).as(Model.class, new RdfObjectMapper(uri));
+                .when().get(uri).as(Model.class, new RdfObjectMapper(uri));
     }
 
     protected Model postContent() {

--- a/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
@@ -3,9 +3,6 @@ package org.w3.ldp.testsuite.test;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.w3.ldp.testsuite.matcher.HttpStatusSuccessMatcher.isSuccessful;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import org.apache.http.HttpStatus;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
@@ -25,8 +22,7 @@ public class MemberResourceTest extends RdfSourceTest {
     private String memberResource;
 
     @Parameters({"memberResource", "directContainer", "indirectContainer", "basicContainer"})
-    public MemberResourceTest(@Optional String memberResource, @Optional String directContainer, @Optional String indirectContainer, @Optional String basicContainer)
-            throws URISyntaxException {
+    public MemberResourceTest(@Optional String memberResource, @Optional String directContainer, @Optional String indirectContainer, @Optional String basicContainer) {
         // If resource is defined, use that. Otherwise, fall back to creating one from one of the containers.
         if (memberResource != null) {
             this.memberResource = memberResource;
@@ -46,7 +42,7 @@ public class MemberResourceTest extends RdfSourceTest {
             Response postResponse =
                     RestAssured.given().contentType(TEXT_TURTLE).body(model, new RdfObjectMapper())
                             .expect().statusCode(HttpStatus.SC_CREATED).header(LOCATION, notNullValue())
-                            .when().post(new URI(this.container));
+                            .when().post(this.container);
 
             this.memberResource = postResponse.getHeader(LOCATION);
         }
@@ -57,10 +53,10 @@ public class MemberResourceTest extends RdfSourceTest {
     }
 
     @AfterClass
-    public void deleteTestResource() throws URISyntaxException {
+    public void deleteTestResource() {
         // If container isn't null, we created the resource ourselves. To clean up, delete the resource.
         if (container != null) {
-            RestAssured.expect().statusCode(isSuccessful()).when().delete(new URI(memberResource));
+            RestAssured.expect().statusCode(isSuccessful()).when().delete(memberResource);
         }
     }
 

--- a/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
@@ -1,7 +1,6 @@
 package org.w3.ldp.testsuite.test;
 
-import com.hp.hpl.jena.rdf.model.Model;
-import com.jayway.restassured.RestAssured;
+import java.io.IOException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
@@ -14,9 +13,8 @@ import org.w3.ldp.testsuite.annotations.SpecTest.STATUS;
 import org.w3.ldp.testsuite.mapper.RdfObjectMapper;
 import org.w3.ldp.testsuite.matcher.HeaderMatchers;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.jayway.restassured.RestAssured;
 
 /**
  * Tests Non-RDF Source LDP resources.
@@ -32,7 +30,7 @@ public abstract class NonRDFSourceTest extends CommonResourceTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#dfn-ldp-server", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testPostResource() throws URISyntaxException, IOException {
+    public void testPostResource() throws IOException {
         // Make sure we can post binary resources
         RestAssured
             .given()
@@ -48,12 +46,12 @@ public abstract class NonRDFSourceTest extends CommonResourceTest {
                                 HeaderMatchers.isLink(org.w3.ldp.testsuite.vocab.LDP.BasicContainer.stringValue(), "type"))
                 )
             .when()
-                .post(new URI(getResourceUri()));
+                .post(getResourceUri());
 
 
         RestAssured.given().header(ACCEPT, TEXT_TURTLE)
                 .expect().statusCode(HttpStatus.SC_OK).contentType(TEXT_TURTLE)
-                .when().get(new URI(getResourceUri())).as(Model.class, new RdfObjectMapper(getResourceUri()));
+                .when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
     }
 
     //TODO: still refactoring tests from Marmotta

--- a/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
@@ -3,7 +3,6 @@ package org.w3.ldp.testsuite.test;
 import static org.testng.Assert.assertTrue;
 import static org.w3.ldp.testsuite.matcher.HttpStatusSuccessMatcher.isSuccessful;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.apache.http.HttpStatus;
@@ -34,13 +33,13 @@ public abstract class RdfSourceTest extends CommonResourceTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-rdf", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testGetResource() throws URISyntaxException {
+    public void testGetResource() {
         // Make sure we can get the resource itself and the response is
         // valid RDF. Turtle is a required media type, so this request
         // should succeed for all LDP-RS.
         RestAssured.given().header(ACCEPT, TEXT_TURTLE)
                 .expect().statusCode(HttpStatus.SC_OK).contentType(TEXT_TURTLE)
-                .when().get(new URI(getResourceUri())).as(Model.class, new RdfObjectMapper(getResourceUri()));
+                .when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
     }
 
     @Test(
@@ -53,7 +52,7 @@ public abstract class RdfSourceTest extends CommonResourceTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-atleast1rdftype", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testContainsRdfType() throws URISyntaxException {
+    public void testContainsRdfType() {
         Model containerModel = getAsModel(getResourceUri());
         Resource r = containerModel.getResource(getResourceUri());
         assertTrue(r.hasProperty(RDF.type), "LDP-RS representation has no explicit rdf:type");
@@ -191,10 +190,10 @@ public abstract class RdfSourceTest extends CommonResourceTest {
     		specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-get-turtle", 
     		testMethod = METHOD.AUTOMATED,
     		approval   = STATUS.WG_APPROVED)
-    public void testGetResourceTurtle() throws URISyntaxException {
+    public void testGetResourceTurtle() {
         RestAssured.given().header(ACCEPT, TEXT_TURTLE)
                 .expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
-                .when().get(new URI(getResourceUri())).as(Model.class, new RdfObjectMapper(getResourceUri()));
+                .when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
     }
 
 }


### PR DESCRIPTION
RestAssured.get(), put(), post(), delete() all can take in a String.
Remove unnecessary calls to new URI() to simplify the code and avoid
URISyntaxException in test method signatures.
