### PR TITLE
Update Reporters to show correct Test Class

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlReporter.java
@@ -94,8 +94,7 @@ public class LdpEarlReporter implements IReporter {
 				Earl.TestMode);
 
 		/* Add properties to the Test Subject Resource */
-		String declaringClass = result.getMethod().getConstructorOrMethod()
-				.getDeclaringClass().getName();
+		String declaringClass = result.getTestClass().getName();
 		subjectResource.addProperty(DCTerms.description, "Declaring Class: "
 				+ declaringClass);
 

--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpHtmlReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpHtmlReporter.java
@@ -285,12 +285,12 @@ public class LdpHtmlReporter implements IReporter {
         for (ITestResult result : tests.getAllResults()) {
             ITestNGMethod method = result.getMethod();
             html.tr();
-            html.td().a(href("#" + method.getMethodName()))
+           html.td()
+					.a(href("#" + method.getTestClass().getName() + "_"
+							+ method.getMethodName()))
                     .write(method.getMethodName(), NO_ESCAPE)._a()._td();
-            html.td().content(
-                    method.getConstructorOrMethod().getDeclaringClass()
-                            .getName()
-            );
+           			html.td().content(method.getTestClass().getName());
+
             html.td().content(
                     (method.getDescription() != null ? method.getDescription()
                             : "No Description found")
@@ -318,12 +318,10 @@ public class LdpHtmlReporter implements IReporter {
         for (ITestResult m : tests.getAllResults()) {
             ITestNGMethod method = m.getMethod();
             html.h2()
-                    .a(id(method.getMethodName()))
-                    .write(method.getMethodName()
-                            + " ("
-                            + method.getConstructorOrMethod()
-                            .getDeclaringClass().getName() + ")")._a()
-                    ._h2();
+                   	.a(id(m.getTestClass().getName() + "_"
+							+ method.getMethodName()))
+					.write(m.getTestClass().getName() + ": "
+							+ method.getMethodName())._a()._h2();
             getAdditionalInfo(m, method);
             html.p(class_("indented"))
                     .b()


### PR DESCRIPTION
have the reports show from which test resource class it came from -
originally it was showing the upper-level classes instead

Change-Id: Ib81dbab19c05fbb6b97819cfad4bdda637fead16
Signed-off-by: ttsanton ttsanton@us.ibm.com
