### PR TITLE
Include additional MAY/SHOULD test cases found in the specification doc

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
@@ -571,6 +571,68 @@ public abstract class CommonContainerTest extends RdfSourceTest {
     public void testProvideLinkHeaderAssociatedRdfSource() {
         // TODO: Impl testProvideLinkHeaderAssociatedRdfSource
     }
+    
+	@Test(
+			enabled = false, 
+			groups = { MAY }, 
+			description = "The representation of a LDPC MAY have an rdf:type "
+					+ "of ldp:Container for Linked Data Platform Container. Non-normative "
+					+ "note: LDPCs might have additional types, like any LDP-RS. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-typecontainer", 
+			testMethod = METHOD.NOT_IMPLEMENTED, 
+			approval = STATUS.WG_PENDING)
+	public void testContainerHasRdfType() {
+		// TODO Impl testcontainerHasRdfType
+	}
+	
+	@Test(
+			enabled = false, 
+			groups = { MAY }, 
+			description = "LDP servers MAY accept an HTTP POST of non-RDF "
+					+ "representations (LDP-NRs) for creation of any kind of "
+					+ "resource, for example binary resources. See the Accept-Post "
+					+ "section for details on how clients can discover whether a "
+					+ "LDPC supports this behavior. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbins", 
+			testMethod = METHOD.NOT_IMPLEMENTED, 
+			approval = STATUS.WG_PENDING)
+	public void testAcceptNonRdfPost() {
+		// TODO Impl TestAcceptNonRdfPost
+	}
+	
+	@Test(
+			enabled = false, 
+			groups = { MAY }, 
+			description = "LDP servers MAY allow clients to suggest "
+					+ "the URI for a resource created through POST, "
+					+ "using the HTTP Slug header as defined in [RFC5023]. "
+					+ "LDP adds no new requirements to this usage, so its "
+					+ "presence functions as a client hint to the server "
+					+ "providing a desired string to be incorporated into the "
+					+ "server's final choice of resource URI.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-slug", 
+			testMethod = METHOD.NOT_IMPLEMENTED, 
+			approval = STATUS.WG_PENDING)
+	public void testAllowSlugUri() {
+		// TODO Impl testAllowSlugUri
+	}
+	
+	@Test(
+			enabled = false, 
+			groups = { SHOULD }, 
+			description = "LDP servers SHOULD accept a request entity "
+					+ "body with a request header of Content-Type with "
+					+ "value of application/ld+json [JSON-LD].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-jsonld", 
+			testMethod = METHOD.NOT_IMPLEMENTED, 
+			approval = STATUS.WG_PENDING)
+	public void testPostJsonLd() {
+		// TODO Impl testPostJsonLd
+	}
 
     protected boolean restrictionsOnContent() {
         return true;

--- a/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
@@ -615,6 +615,19 @@ public abstract class CommonResourceTest extends LdpTest {
         RestAssured.expect().statusCode(isSuccessful()).header(ALLOW, notNullValue())
                 .when().options(getResourceUri());
     }
+    
+	@Test(
+			enabled = false, 
+			groups = { MAY }, 
+			description = "LDP servers MAY choose to allow "
+					+ "the creation of new resources using HTTP PUT. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-create", 
+			testMethod = METHOD.NOT_IMPLEMENTED,
+			approval = STATUS.WG_PENDING)
+	public void testPutCreate() {
+		// TODO Impl testPutCreate
+	}
 
     protected boolean supports(HttpMethod method) {
         return options.contains(method.getName());

--- a/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
@@ -221,4 +221,31 @@ public abstract class RdfSourceTest extends CommonResourceTest {
                 .expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
                 .when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
     }
+    
+	@Test(
+			enabled = false, 
+			groups = { MAY }, 
+			description = "LDP clients MAY provide LDP-defined hints that allow servers "
+					+ "to optimize the content of responses. section 7.2 Preferences on "
+					+ "the Prefer Request Header defines hints that apply to LDP-RSs. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-cli-can-hint", 
+			testMethod = METHOD.NOT_IMPLEMENTED, 
+			approval = STATUS.WG_PENDING)
+	public void testLdpHasHints() {
+		// TODO Impl testLdpHasHints
+	}
+    	
+	@Test(
+			enabled = false, 
+			groups = { SHOULD }, 
+			description = "LDP servers SHOULD offer a application/ld+json representation"
+					+ " of the requested LDP-RS [JSON-LD]. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-get-jsonld", 
+			testMethod = METHOD.NOT_IMPLEMENTED, 
+			approval = STATUS.WG_PENDING)
+	public void testJsonLdRepresentation() {
+		// TODO Impl testJsonLdRepresentation
+	}
 }


### PR DESCRIPTION
Test suite now includes the other test method signatures from the tests
describing may/should requirements in the spec.

They are enabled=false, since they're unimplemented -- good to just have the tests here for later on

Change-Id: I0d6315c009e746ea430997be27c2e8d68b3006c5
Signed-off-by: ttsanton ttsanton@us.ibm.com
