### PR TITLE
Extend the Test Subject

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/LdpTestSuite.java
+++ b/src/main/java/org/w3/ldp/testsuite/LdpTestSuite.java
@@ -18,236 +18,271 @@ import java.util.*;
 
 /**
  * LDP Test Suite Command-Line Interface, a wrapper to {@link org.testng.TestNG}
- *
+ * 
  * @author Sergio Fernández
  * @author Steve Speicher
  * @author Samuel Padgett
  */
 public class LdpTestSuite {
 
-    public static final String NAME = "LDP Test Suite";
+	public static final String NAME = "LDP Test Suite";
 
-    public static final String SPEC_URI = "https://dvcs.w3.org/hg/ldpwg/raw-file/default/ldp.html";
+	public static final String SPEC_URI = "https://dvcs.w3.org/hg/ldpwg/raw-file/default/ldp.html";
 
-    private final TestNG testng;
+	private final TestNG testng;
 
-    enum ContainerType {
-        BASIC, DIRECT, INDIRECT
-    }
+	enum ContainerType {
+		BASIC, DIRECT, INDIRECT
+	}
 
-    ;
+	;
 
-    /**
-     * Basic test suite initialization over a server testing basic containers
-     *
-     * @param server base urtl to the server
-     */
-    public LdpTestSuite(final String server) {
-        this(ImmutableMap.of("server", server, "basic", null));
-    }
+	/**
+	 * Basic test suite initialization over a server testing basic containers
+	 * 
+	 * @param server
+	 *            base urtl to the server
+	 */
+	public LdpTestSuite(final String server) {
+		this(ImmutableMap.of("server", server, "basic", null));
+	}
 
-    /**
-     * Initialize the test suite with options as the row command-line input
-     *
-     * @param cmd command-line options
-     */
-    public LdpTestSuite(final CommandLine cmd) {
-        this(CommandLineUtil.asMap(cmd));
-    }
+	/**
+	 * Initialize the test suite with options as the row command-line input
+	 * 
+	 * @param cmd
+	 *            command-line options
+	 */
+	public LdpTestSuite(final CommandLine cmd) {
+		this(CommandLineUtil.asMap(cmd));
+	}
 
-    /**
-     * Initialize the test suite with a map of options
-     *
-     * @param options options
-     */
-    public LdpTestSuite(final Map<String, String> options) {
+	/**
+	 * Initialize the test suite with a map of options
+	 * 
+	 * @param options
+	 *            options
+	 */
+	public LdpTestSuite(final Map<String, String> options) {
 
-        // see: http://testng.org/doc/documentation-main.html#running-testng-programmatically
-        testng = new TestNG();
-        testng.setDefaultSuiteName(NAME);
+		// see:
+		// http://testng.org/doc/documentation-main.html#running-testng-programmatically
+		testng = new TestNG();
+		testng.setDefaultSuiteName(NAME);
 
-        testng.addListener(new LdpTestListener());
-        testng.addListener(new LdpEarlReporter());
-        testng.addListener(new LdpHtmlReporter());
+		testng.addListener(new LdpTestListener());
+		testng.addListener(new LdpEarlReporter());
+		testng.addListener(new LdpHtmlReporter());
 
-        // create XmlSuite instance
-        XmlSuite testsuite = new XmlSuite();
-        testsuite.setName(NAME);
+		// create XmlSuite instance
+		XmlSuite testsuite = new XmlSuite();
+		testsuite.setName(NAME);
 
-        // provide included/excluded groups
-        // TODO: dynamic groups
-        testsuite.addIncludedGroup(LdpTest.MUST);
-        testsuite.addIncludedGroup(LdpTest.SHOULD);
-        testsuite.addIncludedGroup(LdpTest.MAY);
+		// provide included/excluded groups
+		// TODO: dynamic groups
+		testsuite.addIncludedGroup(LdpTest.MUST);
+		testsuite.addIncludedGroup(LdpTest.SHOULD);
+		testsuite.addIncludedGroup(LdpTest.MAY);
 
-        // create XmlTest instance
-        XmlTest test = new XmlTest(testsuite);
-        test.setName("W3C Linked Data Platform Tests");
+		// create XmlTest instance
+		XmlTest test = new XmlTest(testsuite);
+		test.setName("W3C Linked Data Platform Tests");
 
-        // Add any parameters that you want to set to the Test.
+		// Add any parameters that you want to set to the Test.
 
-        final String server;
-        if (options.containsKey("server")) {
-            server = options.get("server");
-            try {
-                URI uri = new URI(server);
-                if (!"http".equals(uri.getScheme())) {
-                    throw new IllegalArgumentException("non-http uri");
-                }
-            } catch (Exception e) {
-                throw new IllegalArgumentException("ERROR: invalid server uri, "
-                        + e.getLocalizedMessage());
-            }
-        } else {
-            throw new IllegalArgumentException("ERROR: missing server uri");
-        }
+		final String server;
+		if (options.containsKey("server")) {
+			server = options.get("server");
+			try {
+				URI uri = new URI(server);
+				if (!"http".equals(uri.getScheme())) {
+					throw new IllegalArgumentException("non-http uri");
+				}
+			} catch (Exception e) {
+				throw new IllegalArgumentException(
+						"ERROR: invalid server uri, " + e.getLocalizedMessage());
+			}
+		} else {
+			throw new IllegalArgumentException("ERROR: missing server uri");
+		}
 
-        String softwareTitle = null;
-        if (options.containsKey("software"))
-            softwareTitle = options.get("software");
+		String softwareTitle = null;
+		if (options.containsKey("software"))
+			softwareTitle = options.get("software");
+		String softwareDev = null;
+		if (options.containsKey("developer"))
+			softwareDev = options.get("developer");
+		String language = null;
+		if (options.containsKey("language"))
+			language = options.get("language");
+		String homepage = null;
+		if (options.containsKey("homepage"))
+			homepage = options.get("homepage");
 
-        // Add classes we want to test
-        final List<XmlClass> classes = new ArrayList<>();
+		// Add classes we want to test
+		final List<XmlClass> classes = new ArrayList<>();
 
-        final Map<String, String> parameters = new HashMap<>();
+		final Map<String, String> parameters = new HashMap<>();
 
-        if (softwareTitle != null)
-            parameters.put("softwareTitle", softwareTitle);
+		if (softwareTitle != null)
+			parameters.put("software", softwareTitle);
+		if (softwareDev != null)
+			parameters.put("developer", softwareDev);
+		if (language != null)
+			parameters.put("language", language);
+		if (homepage != null)
+			parameters.put("homepage", homepage);
 
-        final ContainerType type = getSelectedType(options);
-        switch (type) {
-            case BASIC:
-                classes.add(new XmlClass("org.w3.ldp.testsuite.test.BasicContainerTest"));
-                parameters.put("basicContainer", server);
-                break;
-            case DIRECT:
-                classes.add(new XmlClass("org.w3.ldp.testsuite.test.DirectContainerTest"));
-                parameters.put("directContainer", server);
-                break;
-            case INDIRECT:
-                classes.add(new XmlClass("org.w3.ldp.testsuite.test.IndirectContainerTest"));
-                parameters.put("indirectContainer", server);
-                break;
-        }
+		final ContainerType type = getSelectedType(options);
+		switch (type) {
+		case BASIC:
+			classes.add(new XmlClass(
+					"org.w3.ldp.testsuite.test.BasicContainerTest"));
+			parameters.put("basicContainer", server);
+			break;
+		case DIRECT:
+			classes.add(new XmlClass(
+					"org.w3.ldp.testsuite.test.DirectContainerTest"));
+			parameters.put("directContainer", server);
+			break;
+		case INDIRECT:
+			classes.add(new XmlClass(
+					"org.w3.ldp.testsuite.test.IndirectContainerTest"));
+			parameters.put("indirectContainer", server);
+			break;
+		}
 
-        classes.add(new XmlClass("org.w3.ldp.testsuite.test.MemberResourceTest"));
-        testsuite.addIncludedGroup("ldpMember");
+		classes.add(new XmlClass("org.w3.ldp.testsuite.test.MemberResourceTest"));
+		testsuite.addIncludedGroup("ldpMember");
 
-        if (options.containsKey("non-rdf")) {
-            classes.add(new XmlClass("org.w3.ldp.testsuite.test.NonRDFSourceTest"));
-            testsuite.addIncludedGroup(LdpTest.NR);
-        }
+		if (options.containsKey("non-rdf")) {
+			classes.add(new XmlClass(
+					"org.w3.ldp.testsuite.test.NonRDFSourceTest"));
+			testsuite.addIncludedGroup(LdpTest.NR);
+		}
 
-        test.setXmlClasses(classes);
+		test.setXmlClasses(classes);
 
-        final List<XmlTest> tests = new ArrayList<>();
-        tests.add(test);
+		final List<XmlTest> tests = new ArrayList<>();
+		tests.add(test);
 
-        testsuite.setParameters(parameters);
-        testsuite.setTests(tests);
+		testsuite.setParameters(parameters);
+		testsuite.setTests(tests);
 
-        final List<XmlSuite> suites = new ArrayList<>();
-        suites.add(testsuite);
+		final List<XmlSuite> suites = new ArrayList<>();
+		suites.add(testsuite);
 
-        // provide our reporter and listener
-        testng.setXmlSuites(suites);
-    }
+		// provide our reporter and listener
+		testng.setXmlSuites(suites);
+	}
 
-    public void run() {
-        testng.run();
-    }
+	public void run() {
+		testng.run();
+	}
 
-    public int getStatus() {
-        return testng.getStatus();
-    }
+	public int getStatus() {
+		return testng.getStatus();
+	}
 
-    @SuppressWarnings("static-access")
-    public static void main(String[] args) {
-        Options options = new Options();
+	@SuppressWarnings("static-access")
+	public static void main(String[] args) {
+		Options options = new Options();
 
-        options.addOption(OptionBuilder.withLongOpt("server")
-                .withDescription("server url to run the test suite")
-                .hasArg().withArgName("server")
-                .isRequired().create());
+		options.addOption(OptionBuilder.withLongOpt("server")
+				.withDescription("server url to run the test suite").hasArg()
+				.withArgName("server").isRequired().create());
 
-        options.addOption(OptionBuilder
-                .withLongOpt("software")
-                .withDescription(
-                        "title of the software test suite runs on")
-                .hasArg().withArgName("software").isRequired(false).create());
+		options.addOption(OptionBuilder.withLongOpt("software")
+				.withDescription("title of the software test suite runs on")
+				.hasArg().withArgName("software").isRequired(false).create());
 
-        OptionGroup containerType = new OptionGroup();
-        containerType.addOption(OptionBuilder.withLongOpt("basic")
-                .withDescription("the server url is a basic container").create());
-        containerType.addOption(OptionBuilder.withLongOpt("direct")
-                .withDescription("the server url is a direct container").create());
-        containerType.addOption(OptionBuilder.withLongOpt("indirect")
-                .withDescription("the server url is an indirect container")
-                .create());
-        containerType.setRequired(true);
-        options.addOptionGroup(containerType);
+		options.addOption(OptionBuilder.withLongOpt("developer")
+				.withDescription("the name of the software developer").hasArg()
+				.withArgName("dev-name").isRequired(false).create());
 
-        options.addOption(OptionBuilder.withLongOpt("non-rdf")
-                .withDescription("include LDP-NR testing").create());
+		options.addOption(OptionBuilder
+				.withLongOpt("language")
+				.withDescription("primary programming language of the software")
+				.hasArg().withArgName("language").isRequired(false).create());
+		options.addOption(OptionBuilder.withLongOpt("homepage")
+				.withDescription("the homepage of the suite runs against")
+				.hasArg().withArgName("homepage").isRequired(false).create());
 
-        options.addOption(OptionBuilder.withLongOpt("help")
-                .withDescription("prints this usage help").create());
+		OptionGroup containerType = new OptionGroup();
+		containerType.addOption(OptionBuilder.withLongOpt("basic")
+				.withDescription("the server url is a basic container")
+				.create());
+		containerType.addOption(OptionBuilder.withLongOpt("direct")
+				.withDescription("the server url is a direct container")
+				.create());
+		containerType.addOption(OptionBuilder.withLongOpt("indirect")
+				.withDescription("the server url is an indirect container")
+				.create());
+		containerType.setRequired(true);
+		options.addOptionGroup(containerType);
 
-        CommandLineParser parser = new BasicParser();
-        CommandLine cmd = null;
-        try {
-            cmd = parser.parse(options, args);
-        } catch (ParseException e) {
-            System.err.println("ERROR: " + e.getLocalizedMessage());
-            printUsage(options);
-        }
+		options.addOption(OptionBuilder.withLongOpt("non-rdf")
+				.withDescription("include LDP-NR testing").create());
 
-        if (cmd.hasOption("help")) {
-            printUsage(options);
-        }
+		options.addOption(OptionBuilder.withLongOpt("help")
+				.withDescription("prints this usage help").create());
 
-        // actual test suite execution
-        try {
-            LdpTestSuite ldpTestSuite = new LdpTestSuite(cmd);
-            ldpTestSuite.run();
-            System.exit(ldpTestSuite.getStatus());
-        } catch (Exception e) {
-            // e.printStackTrace();
-            Throwable cause = ExceptionUtils.getRootCause(e);
-            System.err.println("ERROR: " + (cause != null ? cause.getMessage() : e.getMessage()));
-            printUsage(options);
-        }
+		CommandLineParser parser = new BasicParser();
+		CommandLine cmd = null;
+		try {
+			cmd = parser.parse(options, args);
+		} catch (ParseException e) {
+			System.err.println("ERROR: " + e.getLocalizedMessage());
+			printUsage(options);
+		}
 
-    }
+		if (cmd.hasOption("help")) {
+			printUsage(options);
+		}
 
-    private static ContainerType getSelectedType(Map<String, String> options) {
-        if (options.containsKey("direct")) {
-            return ContainerType.DIRECT;
-        } else if (options.containsKey("indirect")) {
-            return ContainerType.INDIRECT;
-        } else {
-            return ContainerType.BASIC;
-        }
-    }
+		// actual test suite execution
+		try {
+			LdpTestSuite ldpTestSuite = new LdpTestSuite(cmd);
+			ldpTestSuite.run();
+			System.exit(ldpTestSuite.getStatus());
+		} catch (Exception e) {
+			// e.printStackTrace();
+			Throwable cause = ExceptionUtils.getRootCause(e);
+			System.err.println("ERROR: "
+					+ (cause != null ? cause.getMessage() : e.getMessage()));
+			printUsage(options);
+		}
 
-    private static void printUsage(Options options) {
-        HelpFormatter formatter = new HelpFormatter();
-        formatter.setOptionComparator(new Comparator<Option>() {
-            @Override
-            public int compare(Option o1, Option o2) {
-                if ("server".equals(o1.getLongOpt())) {
-                    return -10000;
-                } else if ("help".equals(o1.getLongOpt())) {
-                    return 10000;
-                } else {
-                    return o1.getLongOpt().compareTo(o2.getLongOpt());
-                }
-            }
-        });
-        System.out.println();
-        formatter.printHelp("java -jar ldp-testsuite.jar", options);
-        System.out.println();
-        System.exit(-1);
-    }
+	}
+
+	private static ContainerType getSelectedType(Map<String, String> options) {
+		if (options.containsKey("direct")) {
+			return ContainerType.DIRECT;
+		} else if (options.containsKey("indirect")) {
+			return ContainerType.INDIRECT;
+		} else {
+			return ContainerType.BASIC;
+		}
+	}
+
+	private static void printUsage(Options options) {
+		HelpFormatter formatter = new HelpFormatter();
+		formatter.setOptionComparator(new Comparator<Option>() {
+			@Override
+			public int compare(Option o1, Option o2) {
+				if ("server".equals(o1.getLongOpt())) {
+					return -10000;
+				} else if ("help".equals(o1.getLongOpt())) {
+					return 10000;
+				} else {
+					return o1.getLongOpt().compareTo(o2.getLongOpt());
+				}
+			}
+		});
+		System.out.println();
+		formatter.printHelp("java -jar ldp-testsuite.jar", options);
+		System.out.println();
+		System.exit(-1);
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlReporter.java
@@ -9,7 +9,9 @@ import com.hp.hpl.jena.rdf.model.Literal;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 import com.hp.hpl.jena.rdf.model.Resource;
+import com.hp.hpl.jena.sparql.vocabulary.DOAP;
 import com.hp.hpl.jena.vocabulary.DCTerms;
+
 import org.testng.*;
 import org.testng.internal.Utils;
 import org.testng.xml.XmlSuite;
@@ -27,281 +29,277 @@ import java.util.*;
  */
 public class LdpEarlReporter implements IReporter {
 
-    private BufferedWriter writerTurtle;
-    private BufferedWriter writerJson;
-    private Model model;
+	private BufferedWriter writerTurtle;
+	private BufferedWriter writerJson;
+	private Model model;
 
-    private static final String PASS = "TEST PASSED";
-    private static final String FAIL = "TEST FAILED";
-    private static final String SKIP = "TEST SKIPPED";
-    private static final String TURTLE = "TURTLE";
-    private static final String JSON_LD = "JSON-LD";
-    private static final String outputDir = "report"; // directory where results
-    // will go
+	private static final String PASS = "TEST PASSED";
+	private static final String FAIL = "TEST FAILED";
+	private static final String SKIP = "TEST SKIPPED";
+	private static final String TURTLE = "TURTLE";
+	private static final String JSON_LD = "JSON-LD";
+	private static final String outputDir = "report"; // directory where results
+	// will go
 
-    private static final String DIRECT_TEST = "DirectContainerTest";
-    private static final String MEMBER_TEST = "MemberResourceTest";
-    private static final String BASIC_TEST = "BasicContainerTest";
-    private static final String INDIRECT_TEST = "IndirectContainerTest";
+	// private static final String DIRECT_TEST = "DirectContainerTest";
+	// private static final String MEMBER_TEST = "MemberResourceTest";
+	// private static final String BASIC_TEST = "BasicContainerTest";
+	// private static final String INDIRECT_TEST = "IndirectContainerTest";
+	//
+	// private static String direct;
+	// private static String member;
+	// private static String basic;
+	// private static String indirect;
 
-    private static String defaultUri = "http://localhost:8080/ldp/resources/";
+	private static String softwareTitle;
+	private static String subjectDev;
+	private static String homepage;
+	private static String subjectName;
 
-    private static String direct;
-    private static String member;
-    private static String basic;
-    private static String indirect;
+	private static String language;
 
-    private static String softwareTitle;
+	static {
+		JenaJSONLD.init();
+	}
 
-    static {
-        JenaJSONLD.init();
-    }
+	@Override
+	public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites,
+			String outputDirectory) {
+		try {
+			createWriter(outputDir);
+		} catch (IOException e) {
+		}
+		createModel();
+		createAssertions(suites);
+		write();
+		try {
+			endWriter();
+		} catch (IOException e) {
+		}
+	}
 
-    @Override
-    public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites,
-                               String outputDirectory) {
-        try {
-            createWriter(outputDir);
-        } catch (IOException e) {
-        }
-        createModel();
-        createAssertions(suites);
-        write();
-        try {
-            endWriter();
-        } catch (IOException e) {
-        }
-    }
+	private void createAssertions(List<ISuite> suites) {
+		for (ISuite suite : suites) {
+			// Acquire parameters
+			// direct = suite.getParameter("directContainer");
+			// member = suite.getParameter("memberResource");
+			// basic = suite.getParameter("basicContainer");
+			// indirect = suite.getParameter("indirectContainer");
 
-    private void createAssertions(List<ISuite> suites) {
-        for (ISuite suite : suites) {
-            // Acquire parameters
-            direct = suite.getParameter("directContainer");
-            member = suite.getParameter("memberResource");
-            basic = suite.getParameter("basicContainer");
-            indirect = suite.getParameter("indirectContainer");
+			homepage = suite.getParameter("homepage");
+			subjectName = suite.getParameter("subjectName");
 
-            softwareTitle = suite.getParameter("softwareTitle");
+			softwareTitle = suite.getParameter("software");
+			subjectDev = suite.getParameter("developer");
+			language = suite.getParameter("language");
 
-            // Make the Assertor Resource
-            Resource assertor = model.createResource(null, Earl.Assertor);
-            assertor.addProperty(DCTerms.title, suite.getName());
+			// Make the Assertor Resource
+			Resource assertor = model.createResource(null, Earl.Assertor);
+			assertor.addProperty(DCTerms.title, suite.getName());
 
-            Map<String, ISuiteResult> tests = suite.getResults();
+			Map<String, ISuiteResult> tests = suite.getResults();
 
-            for (ISuiteResult results : tests.values()) {
-                ITestContext testContext = results.getTestContext();
-                getResultProperties(testContext.getFailedTests(), FAIL);
-                getResultProperties(testContext.getSkippedTests(), SKIP);
-                getResultProperties(testContext.getPassedTests(), PASS);
-            }
+			for (ISuiteResult results : tests.values()) {
+				ITestContext testContext = results.getTestContext();
+				getResultProperties(testContext.getFailedTests(), FAIL);
+				getResultProperties(testContext.getSkippedTests(), SKIP);
+				getResultProperties(testContext.getPassedTests(), PASS);
+			}
 
-        }
+		}
 
-    }
+	}
 
-    private void getResultProperties(IResultMap tests, String status) {
-        for (ITestResult result : tests.getAllResults()) {
-            makeResultResource(result, status);
-        }
-    }
+	private void getResultProperties(IResultMap tests, String status) {
+		for (ITestResult result : tests.getAllResults()) {
+			makeResultResource(result, status);
+		}
+	}
 
-    private void makeResultResource(ITestResult result, String status) {
-        Resource assertionResource = model.createResource(null, Earl.Assertion);
-        Resource caseResource = model.createResource(null, Earl.TestCase);
-        Resource subjectResource = model.createResource(null, Earl.TestSubject);
-        Resource resultResource = model.createResource(null, Earl.TestResult);
-        Resource softResource = model.createResource(null, Earl.Software);
-        // Resource modeResource = null;
+	private void makeResultResource(ITestResult result, String status) {
+		Resource assertionResource = model.createResource(null, Earl.Assertion);
+		Resource caseResource = model.createResource(null, Earl.TestCase);
+		Resource subjectResource = model.createResource(null, Earl.TestSubject);
+		Resource resultResource = model.createResource(null, Earl.TestResult);
+		Resource softResource = model.createResource(null, Earl.Software);
+		// Resource modeResource = null;
 
 		/* Add properties to the Test Subject Resource */
 
-        // FIXME
-        String testClass = result.getTestClass().getName();
-        if (testClass.contains(DIRECT_TEST) && direct != null)
-            subjectResource.addProperty(DCTerms.title, direct);
+		// String testClass = result.getTestClass().getName();
 
-        if (testClass.contains(BASIC_TEST) && basic != null)
-            subjectResource.addProperty(DCTerms.title, basic);
+		if (homepage != null)
+			subjectResource.addProperty(DOAP.homepage, homepage);
 
-        if (testClass.contains(INDIRECT_TEST) && indirect != null)
-            subjectResource.addProperty(DCTerms.title, indirect);
+		if (subjectName != null)
+			subjectResource.addProperty(DOAP.name, subjectName);
 
-        if (testClass.contains(MEMBER_TEST)) {
-            if (member != null)
-                subjectResource.addProperty(DCTerms.title, member);
-            else if (direct != null)
-                subjectResource.addProperty(DCTerms.title, direct);
-            else if (basic != null)
-                subjectResource.addProperty(DCTerms.title, basic);
-            else if (indirect != null)
-                subjectResource.addProperty(DCTerms.title, indirect);
-            else
-                subjectResource.addProperty(DCTerms.title, defaultUri);
-
-        }
+		if (subjectDev != null)
+			subjectResource.addProperty(DOAP.developer, subjectDev);
+		if (language != null)
+			subjectResource.addProperty(DOAP.programming_language, language);
 
 		/* Software Resource */
-        if (softwareTitle != null)
-            softResource.addProperty(DCTerms.title, softwareTitle);
+		if (softwareTitle != null)
+			softResource.addProperty(DCTerms.title, softwareTitle);
 
 		/* Test Criterion/Test Case Resource */
-        String declaringClass = result.getTestClass().getName();
+		String declaringClass = result.getTestClass().getName();
 
-        caseResource.addProperty(DCTerms.description, "Declaring Class: "
-                + declaringClass
-                + " - "
-                + (result.getMethod().getDescription() != null ? result
-                .getMethod().getDescription()
-                : "No Description available"));
+		caseResource.addProperty(DCTerms.description, "Declaring Class: "
+				+ declaringClass
+				+ " - "
+				+ (result.getMethod().getDescription() != null ? result
+						.getMethod().getDescription()
+						: "No Description available"));
 
-        String groups = groups(result.getMethod().getGroups());
+		String groups = groups(result.getMethod().getGroups());
 
-        caseResource.addProperty(DCTerms.subject, "Groups: " + groups);
+		caseResource.addProperty(DCTerms.subject, "Groups: " + groups);
 
-        Calendar cal = GregorianCalendar.getInstance();
-        Literal value = model.createTypedLiteral(cal);
-        caseResource.addProperty(DCTerms.date, value);
+		Calendar cal = GregorianCalendar.getInstance();
+		Literal value = model.createTypedLiteral(cal);
+		caseResource.addProperty(DCTerms.date, value);
 
 		/* Test Result Resource */
 
-        // long time = result.getEndMillis() - result.getStartMillis();
-        // resultResource.addProperty(Earl.time, time + " Msec");
+		// long time = result.getEndMillis() - result.getStartMillis();
+		// resultResource.addProperty(Earl.time, time + " Msec");
 
-        resultResource.addProperty(DCTerms.title, status);
-        switch (status) {
-            case FAIL:
-                resultResource.addProperty(Earl.outcome, Earl.fail);
-                break;
-            case PASS:
-                resultResource.addProperty(Earl.outcome, Earl.pass);
-                break;
-            case SKIP:
-                resultResource.addProperty(Earl.outcome, Earl.skip);
-                break;
-            default:
-                break;
-        }
+		resultResource.addProperty(DCTerms.title, status);
+		switch (status) {
+		case FAIL:
+			resultResource.addProperty(Earl.outcome, Earl.fail);
+			break;
+		case PASS:
+			resultResource.addProperty(Earl.outcome, Earl.pass);
+			break;
+		case SKIP:
+			resultResource.addProperty(Earl.outcome, Earl.skip);
+			break;
+		default:
+			break;
+		}
 
-        if (result.getThrowable() != null) {
-            createExceptionProperty(result.getThrowable(), resultResource);
-        }
+		if (result.getThrowable() != null) {
+			createExceptionProperty(result.getThrowable(), resultResource);
+		}
 
-        if (result.getMethod().getConstructorOrMethod().getMethod()
-                .getAnnotation(SpecTest.class) != null) {
+		if (result.getMethod().getConstructorOrMethod().getMethod()
+				.getAnnotation(SpecTest.class) != null) {
 
-            SpecTest test = result.getMethod().getConstructorOrMethod()
-                    .getMethod().getAnnotation(SpecTest.class);
-            METHOD type = test.testMethod();
-            switch (type) {
-                case AUTOMATED:
-                    assertionResource.addProperty(Earl.mode,
-                            model.createResource(Earl.Automatic));
-                    break;
-                case MANUAL:
-                    assertionResource.addProperty(Earl.mode,
-                            model.createResource(Earl.Manual));
-                    break;
-                case NOT_IMPLEMENTED:
-                    assertionResource.addProperty(Earl.mode,
-                            model.createResource(Earl.NotTested));
-                    break;
-                case CLIENT_ONLY:
-                    assertionResource.addProperty(Earl.mode,
-                            model.createResource(Earl.NotTested));
-                    break;
-                default:
-                    assertionResource.addProperty(Earl.mode,
-                            model.createResource(Earl.NotTested));
-                    break;
-            }
-            // modeResource.addProperty(DCTerms.title, type.toString());
-            // modeResource.addProperty(DCTerms.description, result.getName());
-        }
+			SpecTest test = result.getMethod().getConstructorOrMethod()
+					.getMethod().getAnnotation(SpecTest.class);
+			METHOD type = test.testMethod();
+			switch (type) {
+			case AUTOMATED:
+				assertionResource.addProperty(Earl.mode,
+						model.createResource(Earl.Automatic));
+				break;
+			case MANUAL:
+				assertionResource.addProperty(Earl.mode,
+						model.createResource(Earl.Manual));
+				break;
+			case NOT_IMPLEMENTED:
+				assertionResource.addProperty(Earl.mode,
+						model.createResource(Earl.NotTested));
+				break;
+			case CLIENT_ONLY:
+				assertionResource.addProperty(Earl.mode,
+						model.createResource(Earl.NotTested));
+				break;
+			default:
+				assertionResource.addProperty(Earl.mode,
+						model.createResource(Earl.NotTested));
+				break;
+			}
+			// modeResource.addProperty(DCTerms.title, type.toString());
+			// modeResource.addProperty(DCTerms.description, result.getName());
+		}
 
-        // setProperty(Earl.mode, model.createResource(Earl.Automatic));
+		// setProperty(Earl.mode, model.createResource(Earl.Automatic));
 
 		/*
-         * Add the above resources to the Assertion Resource
+		 * Add the above resources to the Assertion Resource
 		 */
-        assertionResource.addProperty(Earl.test, caseResource);
-        assertionResource.addProperty(Earl.testSubject, subjectResource);
-        assertionResource.addProperty(Earl.testResult, resultResource);
-        assertionResource.addProperty(Earl.assertedBy, softResource);
+		assertionResource.addProperty(Earl.test, caseResource);
+		assertionResource.addProperty(Earl.testSubject, subjectResource);
+		assertionResource.addProperty(Earl.testResult, resultResource);
+		assertionResource.addProperty(Earl.assertedBy, softResource);
 
-    }
+	}
 
-    private void createExceptionProperty(Throwable thrown, Resource resource) {
-        if (thrown.getClass().getName().contains(SKIP))
-            resource.addProperty(DCTerms.description, thrown.getMessage());
-        else
-            resource.addLiteral(DCTerms.description,
-                    Utils.stackTrace(thrown, false)[0]);
-    }
+	private void createExceptionProperty(Throwable thrown, Resource resource) {
+		if (thrown.getClass().getName().contains(SKIP))
+			resource.addProperty(DCTerms.description, thrown.getMessage());
+		else
+			resource.addLiteral(DCTerms.description,
+					Utils.stackTrace(thrown, false)[0]);
+	}
 
-    private String groups(String[] list) {
-        if (list.length == 0)
-            return null;
-        String retList = "";
-        for (int i = 0; i < list.length; i++) {
-            if (i == list.length - 1)
-                retList += list[i];
-            else
-                retList += list[i] + ", ";
-        }
-        return retList;
-    }
+	private String groups(String[] list) {
+		if (list.length == 0)
+			return null;
+		String retList = "";
+		for (int i = 0; i < list.length; i++) {
+			if (i == list.length - 1)
+				retList += list[i];
+			else
+				retList += list[i] + ", ";
+		}
+		return retList;
+	}
 
-    private void createWriter(String directory) throws IOException {
-        writerTurtle = null;
-        writerJson = null;
-        new File(directory).mkdirs();
-        writerTurtle = new BufferedWriter(new FileWriter(directory
-                + "/EarlTestSuiteReportTurtle.ttl"));
-        writerJson = new BufferedWriter(new FileWriter(directory
-                + "/EarlTestSuiteReportJsonLd.jsonld", false));
+	private void createWriter(String directory) throws IOException {
+		writerTurtle = null;
+		writerJson = null;
+		new File(directory).mkdirs();
+		writerTurtle = new BufferedWriter(new FileWriter(directory
+				+ "/EarlTestSuiteReportTurtle.ttl"));
+		writerJson = new BufferedWriter(new FileWriter(directory
+				+ "/EarlTestSuiteReportJsonLd.jsonld", false));
 
-    }
+	}
 
-    private void write() {
-        model.write(writerTurtle, TURTLE);
+	private void write() {
+		model.write(writerTurtle, TURTLE);
 
-        StringWriter sw = new StringWriter();
-        model.write(sw, JSON_LD);
-        try {
+		StringWriter sw = new StringWriter();
+		model.write(sw, JSON_LD);
+		try {
 
-            Object jsonObject = JsonUtils.fromString(sw.toString());
+			Object jsonObject = JsonUtils.fromString(sw.toString());
 
-            HashMap<String, String> context = new HashMap<String, String>();
-            // Customise context
-            context.put("dcterms", "http://purl.org/dc/terms/");
-            context.put("earl", "http://www.w3.org/ns/earl#");
-            context.put("foaf", "http://xmlns.com/foaf/0.1/");
-            context.put("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+			HashMap<String, String> context = new HashMap<String, String>();
+			// Customise context
+			context.put("dcterms", "http://purl.org/dc/terms/");
+			context.put("earl", "http://www.w3.org/ns/earl#");
+			context.put("foaf", "http://xmlns.com/foaf/0.1/");
+			context.put("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
 
-            // Create an instance of JsonLdOptions with the standard JSON-LD
-            // options (will just be default for now)
-            JsonLdOptions options = new JsonLdOptions();
-            Object compact = JsonLdProcessor.compact(jsonObject, context,
-                    options);
+			// Create an instance of JsonLdOptions with the standard JSON-LD
+			// options (will just be default for now)
+			JsonLdOptions options = new JsonLdOptions();
+			Object compact = JsonLdProcessor.compact(jsonObject, context,
+					options);
 
-            writerJson.write(JsonUtils.toPrettyString(compact));
-        } catch (IOException | JsonLdError e) {
-            e.printStackTrace();
-        }
+			writerJson.write(JsonUtils.toPrettyString(compact));
+		} catch (IOException | JsonLdError e) {
+			e.printStackTrace();
+		}
 
-    }
+	}
 
-    private void endWriter() throws IOException {
-        writerTurtle.flush();
-        writerTurtle.close();
+	private void endWriter() throws IOException {
+		writerTurtle.flush();
+		writerTurtle.close();
 
-        writerJson.flush();
-        writerTurtle.close();
-    }
+		writerJson.flush();
+		writerTurtle.close();
+	}
 
-    private void createModel() {
-        model = ModelFactory.createDefaultModel();
-    }
+	private void createModel() {
+		model = ModelFactory.createDefaultModel();
+	}
 
 }

--- a/testng.xml
+++ b/testng.xml
@@ -11,7 +11,9 @@
     <!--<parameter name="directContainer" value="http://localhost:8080/ldp/resources/dc-simple/" />-->
     <!-- <parameter name="indirectContainer" value="http://localhost:8080/ldp/resources/" /> -->
 
-    <!-- <parameter name="softwareDescription" value = "TODO: ADD DESCRIPTION" -->
+    <parameter name="language" value = "Java" />
+    <parameter name="homepage" value ="http://eclipse.org/lyo" />
+    <parameter name="subjectName" value="Eclipse Lyo LDP Reference Implementation" />
 
     <!-- Optional RDF member resource parameter. If left out, the tests will
         try to create a resource in one of the containers. -->


### PR DESCRIPTION
Adds in additional information about the TestSubject, for parsing with
Earl, as described in Issue #29.  Also adds in the command-line capability, if you want to add in the information via command line.

There are default values for this -- shown in testng.xml.  

Change-Id: I898eb0093433a2fb42c4403bcb0a3b459cb64fc0
Signed-off-by: ttsanton ttsanton@us.ibm.com
