### PR TITLE
add test class to console output

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpTestListener.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpTestListener.java
@@ -5,30 +5,31 @@ import org.testng.TestListenerAdapter;
 
 public class LdpTestListener extends TestListenerAdapter {
 
-    private static final String FAIL = "Method Failed ";
-    private static final String SKIP = "Method Skipped";
-    private static final String PASSED = "Method Passed";
+    private static final String FAIL = "Failed";
+    private static final String SKIP = "Skipped";
+    private static final String PASSED = "Passed";
 
     @Override
     public void onTestFailure(ITestResult tr) {
-        log(tr.getName(), FAIL, (tr.getEndMillis() - tr.getStartMillis())
-                + " Msec");
+        log(tr, FAIL);
     }
 
     @Override
     public void onTestSkipped(ITestResult tr) {
-        log(tr.getName(), SKIP, (tr.getEndMillis() - tr.getStartMillis())
-                + " Msec");
+        log(tr, SKIP);
     }
 
     @Override
     public void onTestSuccess(ITestResult tr) {
-        log(tr.getName(), PASSED, (tr.getEndMillis() - tr.getStartMillis())
-                + " Msec");
+        log(tr, PASSED);
     }
 
-    private void log(String string, String status, String time) {
-        System.out.printf("%-55s %-15s %15s %n", string, status, time);
+    private void log(ITestResult tr, String status) {
+        System.out.printf(
+                "%-45.45s %-17s %-8s %8s%n",
+                tr.getName(),
+                tr.getTestClass().getRealClass().getSimpleName().replaceAll("Test", ""),
+                status,
+                (tr.getEndMillis() - tr.getStartMillis()) + "ms");
     }
-
 }


### PR DESCRIPTION
Some test methods run multiple times for different resource types.
In the current console output, there's no way to tell which passed
or failed.
