### PR TITLE
Change testETagHeadersGet() to pending 

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
@@ -102,8 +102,7 @@ public abstract class CommonResourceTest extends LdpTest {
     @SpecTest(
             specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-etags",
             testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_CLARIFICATION,
-            comment = "the resource should exist before? (Sergio)")
+            approval = STATUS.WG_PENDING)
     public void testETagHeadersGet() {
         // GET requests
         RestAssured


### PR DESCRIPTION
This test case was marked as needed clarification.  After further review, HTTP defines entity tags as being tied to resource representation.  Only resources that exist can have a representation, so marking it as pending approval.
