### PR TITLE
Same name for two tests

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
@@ -85,7 +85,7 @@ public class NonRDFSourceTest extends CommonResourceTest {
             specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbins",
             testMethod = METHOD.AUTOMATED,
             approval = STATUS.WG_APPROVED)
-    public void testPostResource() throws IOException {
+    public void testPostNonRDFSource() throws IOException {
         // Test constants
         final String slug = "test",
                 file = slug + ".png",


### PR DESCRIPTION
IndirectContainerTest and NonRDFSourceTest classes have a method name in common: testPostResource.
This is a problem when trying the tests individually.

I've renamed the test in NonRDFSourceTest to `testPostNonRDFSource`.
