### PR TITLE
Obsolete test method in testPutBadETag

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
@@ -403,7 +403,7 @@ public abstract class CommonResourceTest extends LdpTest {
                     + "the request [RFC6585].")
     @SpecTest(
             specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond",
-            testMethod = METHOD.NOT_IMPLEMENTED,
+            testMethod = METHOD.AUTOMATED,
             approval = STATUS.WG_APPROVED)
     public void testPutBadETag() {
         skipIfMethodNotAllowed(HttpMethod.PUT);


### PR DESCRIPTION
It says `NOT_IMPLEMENTED` when it really is.
