### PR TITLE
testPutBadETag depends on an unexisting method

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
@@ -393,7 +393,7 @@ public abstract class CommonResourceTest extends LdpTest {
     @Test(
             enabled = false,
             groups = {MUST},
-            //dependsOnMethods = {"testUseHttpIfMatchHeaderAndETags"},
+            dependsOnMethods = {"testPutRequiresIfMatch"},
             description = "LDP servers MUST respond with status code 412 "
                     + "(Condition Failed) if ETags fail to match when there "
                     + "are no other errors with the request [HTTP11]. LDP "


### PR DESCRIPTION
I just commented the line, but I guess it needs two dependencies: testConditionFailedStatusCode and testPreconditionRequiredStatusCode. Is that correct?
