### PR TITLE
testPutBadETag is sending an ETag header

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
@@ -418,7 +418,7 @@ public abstract class CommonResourceTest extends LdpTest {
         RestAssured
             .given()
                 .contentType(response.getContentType())
-                .header(ETAG, "\"This is not the ETag you're looking for\"") // bad ETag value
+                .header(IF_MATCH, "\"This is not the ETag you're looking for\"") // bad ETag value
                 .body(response.asByteArray())
             .expect()
                 .statusCode(HttpStatus.SC_PRECONDITION_FAILED)


### PR DESCRIPTION
I think the right header to send the etag value should be If-Match.
