### PR TITLE
Group names in console report

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpTestListener.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpTestListener.java
@@ -1,35 +1,38 @@
 package org.w3.ldp.testsuite.reporter;
 
+import java.util.Arrays;
+
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
 
 public class LdpTestListener extends TestListenerAdapter {
 
-    private static final String FAIL = "Failed";
-    private static final String SKIP = "Skipped";
-    private static final String PASSED = "Passed";
+	private static final String FAIL = "Failed";
+	private static final String SKIP = "Skipped";
+	private static final String PASSED = "Passed";
 
-    @Override
-    public void onTestFailure(ITestResult tr) {
-        log(tr, FAIL);
-    }
+	@Override
+	public void onTestFailure(ITestResult tr) {
+		log(tr, FAIL);
+	}
 
-    @Override
-    public void onTestSkipped(ITestResult tr) {
-        log(tr, SKIP);
-    }
+	@Override
+	public void onTestSkipped(ITestResult tr) {
+		log(tr, SKIP);
+	}
 
-    @Override
-    public void onTestSuccess(ITestResult tr) {
-        log(tr, PASSED);
-    }
+	@Override
+	public void onTestSuccess(ITestResult tr) {
+		log(tr, PASSED);
+	}
 
-    private void log(ITestResult tr, String status) {
-        System.out.printf(
-                "%-45.45s %-17s %-8s %8s%n",
-                tr.getName(),
-                tr.getTestClass().getRealClass().getSimpleName().replaceAll("Test", ""),
-                status,
-                (tr.getEndMillis() - tr.getStartMillis()) + "ms");
-    }
+	private void log(ITestResult tr, String status) {
+		System.out.printf(
+				"%-45s %-17s %-8s %-15s %8s%n",
+				tr.getName(),
+				tr.getTestClass().getRealClass().getSimpleName()
+						.replaceAll("Test", ""), status,
+				Arrays.toString(tr.getMethod().getGroups()),
+				(tr.getEndMillis() - tr.getStartMillis()) + "ms");
+	}
 }


### PR DESCRIPTION
In cases of failure, it is helpful to see the group that owns the test, as in:

`testPutRequiresIfMatch                        MemberResource    Failed   [SHOULD]            85ms`
