### PR TITLE
Enabling dependent methods automatically

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/transformer/MethodEnabler.java
+++ b/src/main/java/org/w3/ldp/testsuite/transformer/MethodEnabler.java
@@ -33,6 +33,11 @@ public class MethodEnabler implements IAnnotationTransformer {
 		
 		if (transforms.containsKey(methodName)) {
 			annotation.setEnabled(transforms.get(methodName));
+			
+			String[] dependencies = annotation.getDependsOnMethods();
+			for (String dep : dependencies) {
+				transforms.put(dep, true);
+			}
 		} else {	
 			// If it is not in the transforms map and defEnabled is true, 
 			// do what its annotation says


### PR DESCRIPTION
The MethodEnabler only enables tests whose names have been made explicit (_includeMethod(...)_).
This new feature improves its behaviour so that also enables method dependencies.

I guess this could be useful for test selection by argument and wildcards...
