### PR TITLE
Ensure resource deletion in testPostResponseStatusAndLocation

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
@@ -191,16 +191,20 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 	public void testPostResponseStatusAndLocation() throws URISyntaxException {
 		skipIfMethodNotAllowed(HttpMethod.POST);
 
-		Model model = postContent();
-		Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
-				.body(model, new RdfObjectMapper()).expect()
-				.statusCode(HttpStatus.SC_CREATED).when()
-				.post(getResourceUri());
+		String location = null;
 
-		String location = postResponse.getHeader(LOCATION);
-		assertNotNull(location, MSG_LOC_NOTFOUND);
+		try {
+			Model model = postContent();
+			Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
+					.body(model, new RdfObjectMapper()).expect()
+					.statusCode(HttpStatus.SC_CREATED).when()
+					.post(getResourceUri());
 
-		buildBaseRequestSpecification().delete(location);
+			location = postResponse.getHeader(LOCATION);
+			assertNotNull(location, MSG_LOC_NOTFOUND);
+		} finally {
+			buildBaseRequestSpecification().delete(location);
+		}
 	}
 
 	@Test(


### PR DESCRIPTION
There is a problem with the tests which begin with a POST of a resource and end with its deletion. When the expectation of the request is not fulfilled or any of the assertions fails, the sentence that deletes such resource never runs.

I've detected this issue because I am using a server which doesn't allow creating a resource that already exists, but anyway I think it is an implementation flaw.

This request proposes a change in `testPostResponseStatusAndLocation` that ensures deletion whatever happened before. The same pattern could be applied for each test that behaves the same way.
