### PR TITLE
clean up whitespace

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/LdpTestSuite.java
+++ b/src/main/java/org/w3/ldp/testsuite/LdpTestSuite.java
@@ -30,348 +30,348 @@ import java.util.regex.Pattern;
  */
 public class LdpTestSuite {
 
-    public static final String NAME = "LDP Test Suite";
+	public static final String NAME = "LDP Test Suite";
 
-    public static final String SPEC_URI = "https://dvcs.w3.org/hg/ldpwg/raw-file/default/ldp.html";
+	public static final String SPEC_URI = "https://dvcs.w3.org/hg/ldpwg/raw-file/default/ldp.html";
 
-    private final TestNG testng;
+	private final TestNG testng;
 
-    enum ContainerType {
-        BASIC, DIRECT, INDIRECT
-    }
+	enum ContainerType {
+		BASIC, DIRECT, INDIRECT
+	}
 
-    /**
-     * Initialize the test suite with options as a map
-     *
-     * @param options map of options
-     */
-    public LdpTestSuite(final Map<String, String> options) {
-        testng = new TestNG();
-        this.setupSuite(new OptionsHandler(options));
-    }
+	/**
+	 * Initialize the test suite with options as a map
+	 *
+	 * @param options map of options
+	 */
+	public LdpTestSuite(final Map<String, String> options) {
+		testng = new TestNG();
+		this.setupSuite(new OptionsHandler(options));
+	}
 
-    /**
-     * Initialize the test suite with options as the row command-line input
-     *
-     * @param cmd command-line options
-     */
-    public LdpTestSuite(final CommandLine cmd) {
-        // see: http://testng.org/doc/documentation-main.html#running-testng-programmatically
-        testng = new TestNG();
-        this.setupSuite(new OptionsHandler(cmd));
-    }
+	/**
+	 * Initialize the test suite with options as the row command-line input
+	 *
+	 * @param cmd command-line options
+	 */
+	public LdpTestSuite(final CommandLine cmd) {
+		// see: http://testng.org/doc/documentation-main.html#running-testng-programmatically
+		testng = new TestNG();
+		this.setupSuite(new OptionsHandler(cmd));
+	}
 
-    private void setupSuite(OptionsHandler options) {
-        testng.setDefaultSuiteName(NAME);
+	private void setupSuite(OptionsHandler options) {
+		testng.setDefaultSuiteName(NAME);
 
-        // create XmlSuite instance
-        XmlSuite testsuite = new XmlSuite();
-        testsuite.setName(NAME);
+		// create XmlSuite instance
+		XmlSuite testsuite = new XmlSuite();
+		testsuite.setName(NAME);
 
-        // provide included/excluded groups
-        // TODO: dynamic groups
-        testsuite.addIncludedGroup(LdpTest.MUST);
-        testsuite.addIncludedGroup(LdpTest.SHOULD);
-        testsuite.addIncludedGroup(LdpTest.MAY);
+		// provide included/excluded groups
+		// TODO: dynamic groups
+		testsuite.addIncludedGroup(LdpTest.MUST);
+		testsuite.addIncludedGroup(LdpTest.SHOULD);
+		testsuite.addIncludedGroup(LdpTest.MAY);
 
-        // create XmlTest instance
-        XmlTest test = new XmlTest(testsuite);
-        test.setName("W3C Linked Data Platform Tests");
+		// create XmlTest instance
+		XmlTest test = new XmlTest(testsuite);
+		test.setName("W3C Linked Data Platform Tests");
 
-        // Add any parameters that you want to set to the Test.
+		// Add any parameters that you want to set to the Test.
 
-        final String server;
-        if (options.hasOption("server")) {
-            server = options.getOptionValue("server");
-            try {
-                URI uri = new URI(server);
-                if (!"http".equals(uri.getScheme())) {
-                    throw new IllegalArgumentException("non-http uri");
-                }
-            } catch (Exception e) {
-                throw new IllegalArgumentException("ERROR: invalid server uri, " + e.getLocalizedMessage());
-            }
-        } else {
-            throw new IllegalArgumentException("ERROR: missing server uri");
-        }
+		final String server;
+		if (options.hasOption("server")) {
+			server = options.getOptionValue("server");
+			try {
+				URI uri = new URI(server);
+				if (!"http".equals(uri.getScheme())) {
+					throw new IllegalArgumentException("non-http uri");
+				}
+			} catch (Exception e) {
+				throw new IllegalArgumentException("ERROR: invalid server uri, " + e.getLocalizedMessage());
+			}
+		} else {
+			throw new IllegalArgumentException("ERROR: missing server uri");
+		}
 
-        // Listener injection from options
-        final String[] listeners;
-        if (options.hasOption("listeners")) {
-            listeners = options.getOptionValues("listeners");
-            for (String listener : listeners) {
-                try {
-                    Class<?> listenerCl = Class.forName(listener);
-                    Object instance = listenerCl.newInstance();
-                    testng.addListener(instance);
-                } catch (ClassNotFoundException e) {
-                    throw new IllegalArgumentException("ERROR: invalid listener class name, " + e.getLocalizedMessage());
-                } catch (InstantiationException | IllegalAccessException e) {
-                    throw new IllegalArgumentException("ERROR: problem while creating listener, " + e.getLocalizedMessage());
-                }
-            }
-        }
+		// Listener injection from options
+		final String[] listeners;
+		if (options.hasOption("listeners")) {
+			listeners = options.getOptionValues("listeners");
+			for (String listener : listeners) {
+				try {
+					Class<?> listenerCl = Class.forName(listener);
+					Object instance = listenerCl.newInstance();
+					testng.addListener(instance);
+				} catch (ClassNotFoundException e) {
+					throw new IllegalArgumentException("ERROR: invalid listener class name, " + e.getLocalizedMessage());
+				} catch (InstantiationException | IllegalAccessException e) {
+					throw new IllegalArgumentException("ERROR: problem while creating listener, " + e.getLocalizedMessage());
+				}
+			}
+		}
 
-        testng.addListener(new LdpTestListener());
-        testng.addListener(new LdpEarlReporter());
-        testng.addListener(new LdpHtmlReporter());
+		testng.addListener(new LdpTestListener());
+		testng.addListener(new LdpEarlReporter());
+		testng.addListener(new LdpHtmlReporter());
 
-        // Add method enabler (Annotation Transformer)
-        testng.addListener(new MethodEnabler());
+		// Add method enabler (Annotation Transformer)
+		testng.addListener(new MethodEnabler());
 
-        // Test suite parameters
-        final Map<String, String> parameters = new HashMap<>();
+		// Test suite parameters
+		final Map<String, String> parameters = new HashMap<>();
 
-        if (options.hasOptionWithValue("software"))
-            parameters.put("software", options.getOptionValue("software"));
+		if (options.hasOptionWithValue("software"))
+			parameters.put("software", options.getOptionValue("software"));
 
-        if (options.hasOptionWithValue("developer"))
-            parameters.put("software", options.getOptionValue("developer"));
+		if (options.hasOptionWithValue("developer"))
+			parameters.put("software", options.getOptionValue("developer"));
 
-        if (options.hasOptionWithValue("language"))
-            parameters.put("language", options.getOptionValue("language"));
+		if (options.hasOptionWithValue("language"))
+			parameters.put("language", options.getOptionValue("language"));
 
-        if (options.hasOptionWithValue("homepage"))
-            parameters.put("homepage", options.getOptionValue("homepage"));
+		if (options.hasOptionWithValue("homepage"))
+			parameters.put("homepage", options.getOptionValue("homepage"));
 
-        if (options.hasOptionWithValue("cont-res")) {
-            final String containerAsResource = options.getOptionValue("cont-res");
-            try {
-                URI uri = new URI(containerAsResource);
-                if (!"http".equals(uri.getScheme())) {
-                    throw new IllegalArgumentException("ERROR: non-http uri");
-                }
-            } catch (Exception e) {
-                throw new IllegalArgumentException("ERROR: invalid containerAsResource uri, " + e.getLocalizedMessage());
-            }
-            parameters.put("containerAsResource", containerAsResource);
-        }
+		if (options.hasOptionWithValue("cont-res")) {
+			final String containerAsResource = options.getOptionValue("cont-res");
+			try {
+				URI uri = new URI(containerAsResource);
+				if (!"http".equals(uri.getScheme())) {
+					throw new IllegalArgumentException("ERROR: non-http uri");
+				}
+			} catch (Exception e) {
+				throw new IllegalArgumentException("ERROR: invalid containerAsResource uri, " + e.getLocalizedMessage());
+			}
+			parameters.put("containerAsResource", containerAsResource);
+		}
 
-        if (options.hasOptionWithValue("auth")) {
-            final String auth = options.getOptionValue("auth");
-            if (auth.contains(":")) {
-                    String[] split = auth.split(":");
-                    if (split.length == 2 && StringUtils.isNotBlank(split[0]) && StringUtils.isNotBlank(split[1])) {
-                        parameters.put("auth", auth);
-                } else {
-                    throw new IllegalArgumentException("ERROR: invalid basic authentication credentials");
-                }
-            } else {
-                throw new IllegalArgumentException("ERROR: invalid basic authentication credentials");
-            }
-        }
+		if (options.hasOptionWithValue("auth")) {
+			final String auth = options.getOptionValue("auth");
+			if (auth.contains(":")) {
+					String[] split = auth.split(":");
+					if (split.length == 2 && StringUtils.isNotBlank(split[0]) && StringUtils.isNotBlank(split[1])) {
+						parameters.put("auth", auth);
+				} else {
+					throw new IllegalArgumentException("ERROR: invalid basic authentication credentials");
+				}
+			} else {
+				throw new IllegalArgumentException("ERROR: invalid basic authentication credentials");
+			}
+		}
 
-        // Add classes we want to test
-        final List<XmlClass> classes = new ArrayList<>();
+		// Add classes we want to test
+		final List<XmlClass> classes = new ArrayList<>();
 
-        final ContainerType type = getSelectedType(options);
-        switch (type) {
-            case BASIC:
-                classes.add(new XmlClass( "org.w3.ldp.testsuite.test.BasicContainerTest"));
-                parameters.put("basicContainer", server);
-                break;
-            case DIRECT:
-                classes.add(new XmlClass("org.w3.ldp.testsuite.test.DirectContainerTest"));
-                parameters.put("directContainer", server);
-                break;
-            case INDIRECT:
-                classes.add(new XmlClass("org.w3.ldp.testsuite.test.IndirectContainerTest"));
-                parameters.put("indirectContainer", server);
-                break;
-        }
+		final ContainerType type = getSelectedType(options);
+		switch (type) {
+			case BASIC:
+				classes.add(new XmlClass( "org.w3.ldp.testsuite.test.BasicContainerTest"));
+				parameters.put("basicContainer", server);
+				break;
+			case DIRECT:
+				classes.add(new XmlClass("org.w3.ldp.testsuite.test.DirectContainerTest"));
+				parameters.put("directContainer", server);
+				break;
+			case INDIRECT:
+				classes.add(new XmlClass("org.w3.ldp.testsuite.test.IndirectContainerTest"));
+				parameters.put("indirectContainer", server);
+				break;
+		}
 
-        final String post;
-        if (options.hasOption("post")) {
-            post = options.getOptionValue("post");
-            parameters.put("post", post);
-        }
+		final String post;
+		if (options.hasOption("post")) {
+			post = options.getOptionValue("post");
+			parameters.put("post", post);
+		}
 
-        final String memberResource;
-        if (options.hasOption("memberResource")) {
-            memberResource = options.getOptionValue("memberResource");
-            parameters.put("memberResource", memberResource);
-        }
+		final String memberResource;
+		if (options.hasOption("memberResource")) {
+			memberResource = options.getOptionValue("memberResource");
+			parameters.put("memberResource", memberResource);
+		}
 
-        classes.add(new XmlClass("org.w3.ldp.testsuite.test.MemberResourceTest"));
-        testsuite.addIncludedGroup("ldpMember");
+		classes.add(new XmlClass("org.w3.ldp.testsuite.test.MemberResourceTest"));
+		testsuite.addIncludedGroup("ldpMember");
 
-        if (options.hasOption("non-rdf")) {
-            classes.add(new XmlClass("org.w3.ldp.testsuite.test.NonRDFSourceTest"));
-            testsuite.addIncludedGroup(LdpTest.NR);
-        }
+		if (options.hasOption("non-rdf")) {
+			classes.add(new XmlClass("org.w3.ldp.testsuite.test.NonRDFSourceTest"));
+			testsuite.addIncludedGroup(LdpTest.NR);
+		}
 
-        test.setXmlClasses(classes);
+		test.setXmlClasses(classes);
 
-        final List<XmlTest> tests = new ArrayList<>();
-        tests.add(test);
+		final List<XmlTest> tests = new ArrayList<>();
+		tests.add(test);
 
-        testsuite.setParameters(parameters);
-        testsuite.setTests(tests);
+		testsuite.setParameters(parameters);
+		testsuite.setTests(tests);
 
-        final List<XmlSuite> suites = new ArrayList<>();
-        suites.add(testsuite);
-        testng.setXmlSuites(suites);
+		final List<XmlSuite> suites = new ArrayList<>();
+		suites.add(testsuite);
+		testng.setXmlSuites(suites);
 
-        if (options.hasOption("test")) {
-            final String[] testNamePatterns = options.getOptionValues("test");
-            for (int i = 0; i < testNamePatterns.length; i++) {
-                // We support only * as a wildcard character to keep the command line simple.
-                // Convert the wildcard pattern into a regex to use internally.
-                testNamePatterns[i] = wildcardPatternToRegex(testNamePatterns[i]);
-            }
+		if (options.hasOption("test")) {
+			final String[] testNamePatterns = options.getOptionValues("test");
+			for (int i = 0; i < testNamePatterns.length; i++) {
+				// We support only * as a wildcard character to keep the command line simple.
+				// Convert the wildcard pattern into a regex to use internally.
+				testNamePatterns[i] = wildcardPatternToRegex(testNamePatterns[i]);
+			}
 
-            // Add a method intercepter to filter the list for matching tests.
-            testng.addListener(new IMethodInterceptor() {
-                @Override
-                public List<IMethodInstance> intercept(List<IMethodInstance> methods, ITestContext context) {
-                    ArrayList<IMethodInstance> toRun = new ArrayList<>();
-                    for (IMethodInstance method : methods) {
-                        for (String testNamePattern : testNamePatterns) {
-                            if (method.getMethod().getMethodName().matches(testNamePattern)) {
-                                toRun.add(method);
-                            }
-                        }
-                    }
-                    return toRun;
-                }
-            });
-        }
-    }
+			// Add a method intercepter to filter the list for matching tests.
+			testng.addListener(new IMethodInterceptor() {
+				@Override
+				public List<IMethodInstance> intercept(List<IMethodInstance> methods, ITestContext context) {
+					ArrayList<IMethodInstance> toRun = new ArrayList<>();
+					for (IMethodInstance method : methods) {
+						for (String testNamePattern : testNamePatterns) {
+							if (method.getMethod().getMethodName().matches(testNamePattern)) {
+								toRun.add(method);
+							}
+						}
+					}
+					return toRun;
+				}
+			});
+		}
+	}
 
-    public String wildcardPatternToRegex(String wildcardPattern) {
-        // use lookarounds and zero-width matches to include the * delimeter in the result
-        String[] tokens = wildcardPattern.split("(?<=\\*)|(?=\\*)");
-        StringBuilder builder = new StringBuilder();
-        for (String token : tokens) {
-            if ("*".equals(token)) {
-                builder.append(".*");
-            } else if (token.length() > 0) {
-                builder.append(Pattern.quote(token));
-            }
-        }
+	public String wildcardPatternToRegex(String wildcardPattern) {
+		// use lookarounds and zero-width matches to include the * delimeter in the result
+		String[] tokens = wildcardPattern.split("(?<=\\*)|(?=\\*)");
+		StringBuilder builder = new StringBuilder();
+		for (String token : tokens) {
+			if ("*".equals(token)) {
+				builder.append(".*");
+			} else if (token.length() > 0) {
+				builder.append(Pattern.quote(token));
+			}
+		}
 
-        return builder.toString();
-    }
+		return builder.toString();
+	}
 
-    public void run() {
-        testng.run();
-    }
+	public void run() {
+		testng.run();
+	}
 
-    public int getStatus() {
-        return testng.getStatus();
-    }
+	public int getStatus() {
+		return testng.getStatus();
+	}
 
-    @SuppressWarnings("static-access")
-    public static void main(String[] args) {
-        Options options = new Options();
+	@SuppressWarnings("static-access")
+	public static void main(String[] args) {
+		Options options = new Options();
 
-        options.addOption(OptionBuilder.withLongOpt("server")
-                .withDescription("server url to run the test suite").hasArg()
-                .withArgName("server").isRequired().create());
+		options.addOption(OptionBuilder.withLongOpt("server")
+				.withDescription("server url to run the test suite").hasArg()
+				.withArgName("server").isRequired().create());
 
-        options.addOption(OptionBuilder.withLongOpt("auth")
-                .withDescription("server basic authentication credentials following the syntax username:password").hasArg()
-                .withArgName("username:password").create());
+		options.addOption(OptionBuilder.withLongOpt("auth")
+				.withDescription("server basic authentication credentials following the syntax username:password").hasArg()
+				.withArgName("username:password").create());
 
-        options.addOption(OptionBuilder.withLongOpt("software")
-                .withDescription("title of the software test suite runs on")
-                .hasArg().withArgName("software").isRequired(false).create());
+		options.addOption(OptionBuilder.withLongOpt("software")
+				.withDescription("title of the software test suite runs on")
+				.hasArg().withArgName("software").isRequired(false).create());
 
-        options.addOption(OptionBuilder.withLongOpt("developer")
-                .withDescription("the name of the software developer").hasArg()
-                .withArgName("dev-name").isRequired(false).create());
+		options.addOption(OptionBuilder.withLongOpt("developer")
+				.withDescription("the name of the software developer").hasArg()
+				.withArgName("dev-name").isRequired(false).create());
 
-        options.addOption(OptionBuilder
-                .withLongOpt("language")
-                .withDescription("primary programming language of the software")
-                .hasArg().withArgName("language").isRequired(false).create());
-        options.addOption(OptionBuilder.withLongOpt("homepage")
-                .withDescription("the homepage of the suite runs against")
-                .hasArg().withArgName("homepage").isRequired(false).create());
+		options.addOption(OptionBuilder
+				.withLongOpt("language")
+				.withDescription("primary programming language of the software")
+				.hasArg().withArgName("language").isRequired(false).create());
+		options.addOption(OptionBuilder.withLongOpt("homepage")
+				.withDescription("the homepage of the suite runs against")
+				.hasArg().withArgName("homepage").isRequired(false).create());
 
-        OptionGroup containerType = new OptionGroup();
-        containerType.addOption(OptionBuilder.withLongOpt("basic")
-                .withDescription("the server url is a basic container")
-                .create());
-        containerType.addOption(OptionBuilder.withLongOpt("direct")
-                .withDescription("the server url is a direct container")
-                .create());
-        containerType.addOption(OptionBuilder.withLongOpt("indirect")
-                .withDescription("the server url is an indirect container")
-                .create());
-        containerType.setRequired(true);
-        options.addOptionGroup(containerType);
+		OptionGroup containerType = new OptionGroup();
+		containerType.addOption(OptionBuilder.withLongOpt("basic")
+				.withDescription("the server url is a basic container")
+				.create());
+		containerType.addOption(OptionBuilder.withLongOpt("direct")
+				.withDescription("the server url is a direct container")
+				.create());
+		containerType.addOption(OptionBuilder.withLongOpt("indirect")
+				.withDescription("the server url is an indirect container")
+				.create());
+		containerType.setRequired(true);
+		options.addOptionGroup(containerType);
 
-        options.addOption(OptionBuilder.withLongOpt("non-rdf")
-                .withDescription("include LDP-NR testing").create());
+		options.addOption(OptionBuilder.withLongOpt("non-rdf")
+				.withDescription("include LDP-NR testing").create());
 
-        options.addOption(OptionBuilder.withLongOpt("test")
-                .withDescription("which tests to run (* is a wildcard)")
-                .hasArgs().withArgName("test names")
-                .create());
+		options.addOption(OptionBuilder.withLongOpt("test")
+				.withDescription("which tests to run (* is a wildcard)")
+				.hasArgs().withArgName("test names")
+				.create());
 
-        options.addOption(OptionBuilder.withLongOpt("cont-res")
-                .withDescription("url of a container with interaction model of a resource").hasArg()
-                .withArgName("cont-res").create());
+		options.addOption(OptionBuilder.withLongOpt("cont-res")
+				.withDescription("url of a container with interaction model of a resource").hasArg()
+				.withArgName("cont-res").create());
 
-        options.addOption(OptionBuilder.withLongOpt("help")
-                .withDescription("prints this usage help").create());
+		options.addOption(OptionBuilder.withLongOpt("help")
+				.withDescription("prints this usage help").create());
 
-        CommandLineParser parser = new BasicParser();
-        CommandLine cmd = null;
-        try {
-            cmd = parser.parse(options, args);
-        } catch (ParseException e) {
-            System.err.println("ERROR: " + e.getLocalizedMessage());
-            printUsage(options);
-        }
+		CommandLineParser parser = new BasicParser();
+		CommandLine cmd = null;
+		try {
+			cmd = parser.parse(options, args);
+		} catch (ParseException e) {
+			System.err.println("ERROR: " + e.getLocalizedMessage());
+			printUsage(options);
+		}
 
-        if (cmd.hasOption("help")) {
-            printUsage(options);
-        }
+		if (cmd.hasOption("help")) {
+			printUsage(options);
+		}
 
-        // actual test suite execution
-        try {
-            LdpTestSuite ldpTestSuite = new LdpTestSuite(cmd);
-            ldpTestSuite.run();
-            System.exit(ldpTestSuite.getStatus());
-        } catch (Exception e) {
-            e.printStackTrace();
-            Throwable cause = ExceptionUtils.getRootCause(e);
-            System.err.println("ERROR: " + (cause != null ? cause.getMessage() : e.getMessage()));
-            printUsage(options);
-        }
+		// actual test suite execution
+		try {
+			LdpTestSuite ldpTestSuite = new LdpTestSuite(cmd);
+			ldpTestSuite.run();
+			System.exit(ldpTestSuite.getStatus());
+		} catch (Exception e) {
+			e.printStackTrace();
+			Throwable cause = ExceptionUtils.getRootCause(e);
+			System.err.println("ERROR: " + (cause != null ? cause.getMessage() : e.getMessage()));
+			printUsage(options);
+		}
 
-    }
+	}
 
-    private static ContainerType getSelectedType(OptionsHandler options) {
-        if (options.hasOption("direct")) {
-            return ContainerType.DIRECT;
-        } else if (options.hasOption("indirect")) {
-            return ContainerType.INDIRECT;
-        } else {
-            return ContainerType.BASIC;
-        }
-    }
+	private static ContainerType getSelectedType(OptionsHandler options) {
+		if (options.hasOption("direct")) {
+			return ContainerType.DIRECT;
+		} else if (options.hasOption("indirect")) {
+			return ContainerType.INDIRECT;
+		} else {
+			return ContainerType.BASIC;
+		}
+	}
 
-    private static void printUsage(Options options) {
-        HelpFormatter formatter = new HelpFormatter();
-        formatter.setOptionComparator(new Comparator<Option>() {
-            @Override
-            public int compare(Option o1, Option o2) {
-                if ("server".equals(o1.getLongOpt())) {
-                    return -10000;
-                } else if ("help".equals(o1.getLongOpt())) {
-                    return 10000;
-                } else {
-                    return o1.getLongOpt().compareTo(o2.getLongOpt());
-                }
-            }
-        });
-        System.out.println();
-        formatter.printHelp("java -jar ldp-testsuite.jar", options);
-        System.out.println();
-        System.exit(-1);
-    }
+	private static void printUsage(Options options) {
+		HelpFormatter formatter = new HelpFormatter();
+		formatter.setOptionComparator(new Comparator<Option>() {
+			@Override
+			public int compare(Option o1, Option o2) {
+				if ("server".equals(o1.getLongOpt())) {
+					return -10000;
+				} else if ("help".equals(o1.getLongOpt())) {
+					return 10000;
+				} else {
+					return o1.getLongOpt().compareTo(o2.getLongOpt());
+				}
+			}
+		});
+		System.out.println();
+		formatter.printHelp("java -jar ldp-testsuite.jar", options);
+		System.out.println();
+		System.exit(-1);
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/annotations/SpecTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/annotations/SpecTest.java
@@ -6,51 +6,51 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SpecTest {
 
-    /**
-     * WG_PENDING (default) - no official recommendation from the WG supporting
-     * the specification being tested by this test suite.
-     * WG_APPROVED - working group has approved this test case
-     * WG_CLARIFICATION - requires further clarification from the working group
-     * WG_DEPRECATED - no longer recommended by WG
-     * WG_EXTENSION - valuable test case but not part of the WG approved set
-     */
-    public static enum STATUS {
-        WG_PENDING, WG_APPROVED, WG_DEPRECATED, WG_EXTENSION, WG_CLARIFICATION
-    }
+	/**
+	 * WG_PENDING (default) - no official recommendation from the WG supporting
+	 * the specification being tested by this test suite.
+	 * WG_APPROVED - working group has approved this test case
+	 * WG_CLARIFICATION - requires further clarification from the working group
+	 * WG_DEPRECATED - no longer recommended by WG
+	 * WG_EXTENSION - valuable test case but not part of the WG approved set
+	 */
+	public static enum STATUS {
+		WG_PENDING, WG_APPROVED, WG_DEPRECATED, WG_EXTENSION, WG_CLARIFICATION
+	}
 
-    ;
+	;
 
-    /**
-     * The URI of the spec
-     */
-    public String specRefUri() default "No Specification URI";
+	/**
+	 * The URI of the spec
+	 */
+	public String specRefUri() default "No Specification URI";
 
-    /**
-     * The status of the test case, pending or approved
-     */
-    public STATUS approval() default STATUS.WG_PENDING;
+	/**
+	 * The status of the test case, pending or approved
+	 */
+	public STATUS approval() default STATUS.WG_PENDING;
 
-    /**
-     * Many of these values are used for reporting purposes and have these
-     * meanings:
-     * <p/>
-     * NOT_IMPLEMENTED (default) - possible to implement, just not done
-     * AUTOMATED - implementation complete
-     * MANUAL - server test but not automated
-     * CLIENT_ONLY - test is only client-side, this test suite doesn't test it.
-     */
-    public static enum METHOD {
-        NOT_IMPLEMENTED, AUTOMATED, MANUAL, CLIENT_ONLY
-    };
+	/**
+	 * Many of these values are used for reporting purposes and have these
+	 * meanings:
+	 * <p/>
+	 * NOT_IMPLEMENTED (default) - possible to implement, just not done
+	 * AUTOMATED - implementation complete
+	 * MANUAL - server test but not automated
+	 * CLIENT_ONLY - test is only client-side, this test suite doesn't test it.
+	 */
+	public static enum METHOD {
+		NOT_IMPLEMENTED, AUTOMATED, MANUAL, CLIENT_ONLY
+	};
 
-    /**
-     * Whether the test case itself has been implemented or not
-     */
-    public METHOD testMethod() default METHOD.NOT_IMPLEMENTED;
+	/**
+	 * Whether the test case itself has been implemented or not
+	 */
+	public METHOD testMethod() default METHOD.NOT_IMPLEMENTED;
 
-    /**
-     * Whether further comment that can be useful
-     */
-    public String comment() default "";
+	/**
+	 * Whether further comment that can be useful
+	 */
+	public String comment() default "";
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/data/MediaTypeDataProvider.java
+++ b/src/main/java/org/w3/ldp/testsuite/data/MediaTypeDataProvider.java
@@ -4,11 +4,11 @@ import org.testng.annotations.DataProvider;
 import org.w3.ldp.testsuite.http.MediaTypes;
 
 public class MediaTypeDataProvider implements MediaTypes {
-    public final static String NAME = "mediaTypes";
+	public final static String NAME = "mediaTypes";
 
-    @DataProvider(name = NAME)
-    public static Object[][] createData() {
-        // TODO: Make the supported media types configurable.
-        return new Object[][]{{TEXT_TURTLE}, {APPLICATION_RDF_XML}};
-    }
+	@DataProvider(name = NAME)
+	public static Object[][] createData() {
+		// TODO: Make the supported media types configurable.
+		return new Object[][]{{TEXT_TURTLE}, {APPLICATION_RDF_XML}};
+	}
 }

--- a/src/main/java/org/w3/ldp/testsuite/exception/SkipClientTestException.java
+++ b/src/main/java/org/w3/ldp/testsuite/exception/SkipClientTestException.java
@@ -3,9 +3,9 @@ package org.w3.ldp.testsuite.exception;
 import org.testng.SkipException;
 
 public class SkipClientTestException extends SkipException {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    public SkipClientTestException() {
-        super("Skipping test. This is a client requirement, not a server requirement.");
-    }
+	public SkipClientTestException() {
+		super("Skipping test. This is a client requirement, not a server requirement.");
+	}
 }

--- a/src/main/java/org/w3/ldp/testsuite/exception/SkipMethodNotAllowedException.java
+++ b/src/main/java/org/w3/ldp/testsuite/exception/SkipMethodNotAllowedException.java
@@ -4,15 +4,15 @@ import org.testng.SkipException;
 import org.w3.ldp.testsuite.http.HttpMethod;
 
 public class SkipMethodNotAllowedException extends SkipException {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    public SkipMethodNotAllowedException(HttpMethod method) {
-        super("Skipping test since method " + method.getName() +
-                " is not allowed. This HTTP method is needed for this test.");
-    }
+	public SkipMethodNotAllowedException(HttpMethod method) {
+		super("Skipping test since method " + method.getName() +
+				" is not allowed. This HTTP method is needed for this test.");
+	}
 
-    public SkipMethodNotAllowedException(String uri, HttpMethod method) {
-        super("Skipping test since <" + uri + "> has not advertised " + method.getName() +
-                " support through its HTTP OPTIONS response. This HTTP method is needed for this test.");
-    }
+	public SkipMethodNotAllowedException(String uri, HttpMethod method) {
+		super("Skipping test since <" + uri + "> has not advertised " + method.getName() +
+				" support through its HTTP OPTIONS response. This HTTP method is needed for this test.");
+	}
 }

--- a/src/main/java/org/w3/ldp/testsuite/exception/SkipNotTestableException.java
+++ b/src/main/java/org/w3/ldp/testsuite/exception/SkipNotTestableException.java
@@ -3,9 +3,9 @@ package org.w3.ldp.testsuite.exception;
 import org.testng.SkipException;
 
 public class SkipNotTestableException extends SkipException {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    public SkipNotTestableException() {
-        super("This requirement or recommendation must be tested manually. It is difficult or impossible to write automated tests for and is not part of the testsuite.");
-    }
+	public SkipNotTestableException() {
+		super("This requirement or recommendation must be tested manually. It is difficult or impossible to write automated tests for and is not part of the testsuite.");
+	}
 }

--- a/src/main/java/org/w3/ldp/testsuite/http/HttpHeaders.java
+++ b/src/main/java/org/w3/ldp/testsuite/http/HttpHeaders.java
@@ -2,16 +2,16 @@ package org.w3.ldp.testsuite.http;
 
 
 public interface HttpHeaders {
-    public static final String ACCEPT = "Accept";
-    public static final String ACCEPT_PATCH = "Accept-Patch";
-    public static final String ACCEPT_POST = "Accept-Post";
-    public static final String ALLOW = "Allow";
-    public static final String ETAG = "ETAG";
-    public static final String IF_MATCH = "If-Match";
-    public static final String LINK = "Link";
-    public static final String LINK_REL_TYPE = "type";
-    public static final String LOCATION = "Location";
-    public static final String PREFER = "Prefer";
-    public static final String PREFERNCE_APPLIED = "Preference-Applied";
-    public static final String SLUG = "Slug";
+	public static final String ACCEPT = "Accept";
+	public static final String ACCEPT_PATCH = "Accept-Patch";
+	public static final String ACCEPT_POST = "Accept-Post";
+	public static final String ALLOW = "Allow";
+	public static final String ETAG = "ETAG";
+	public static final String IF_MATCH = "If-Match";
+	public static final String LINK = "Link";
+	public static final String LINK_REL_TYPE = "type";
+	public static final String LOCATION = "Location";
+	public static final String PREFER = "Prefer";
+	public static final String PREFERNCE_APPLIED = "Preference-Applied";
+	public static final String SLUG = "Slug";
 }

--- a/src/main/java/org/w3/ldp/testsuite/http/HttpMethod.java
+++ b/src/main/java/org/w3/ldp/testsuite/http/HttpMethod.java
@@ -2,22 +2,22 @@ package org.w3.ldp.testsuite.http;
 
 public enum HttpMethod {
 
-    GET("GET"),
-    PUT("PUT"),
-    POST("POST"),
-    DELETE("DELETE"),
-    PATCH("PATCH"),
-    HEAD("HEAD"),
-    OPTIONS("OPTIONS");
+	GET("GET"),
+	PUT("PUT"),
+	POST("POST"),
+	DELETE("DELETE"),
+	PATCH("PATCH"),
+	HEAD("HEAD"),
+	OPTIONS("OPTIONS");
 
-    private String name;
+	private String name;
 
-    HttpMethod(String name) {
-        this.name = name;
-    }
+	HttpMethod(String name) {
+		this.name = name;
+	}
 
-    public String getName() {
-        return name;
-    }
+	public String getName() {
+		return name;
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/http/LdpPreferences.java
+++ b/src/main/java/org/w3/ldp/testsuite/http/LdpPreferences.java
@@ -8,9 +8,9 @@ import org.w3.ldp.testsuite.vocab.LDP;
  * @see <a href="https://dvcs.w3.org/hg/ldpwg/raw-file/default/ldp.html#prefer-parameters">LDP 1.0: Prefer Parameters</a>
  */
 public interface LdpPreferences {
-    public static final String PREFERENCE_INCLUDE = "include";
-    public static final String PREFERENCE_OMIT = "omit";
-    public static final String PREFER_MINIMAL_CONTAINER = LDP.NAMESPACE + "PreferMinimalContainer";
-    public static final String PREFER_CONTAINMENT = LDP.NAMESPACE + "PreferContainment";
-    public static final String PREFER_MEMBERSHIP = LDP.NAMESPACE + "PreferMembership";
+	public static final String PREFERENCE_INCLUDE = "include";
+	public static final String PREFERENCE_OMIT = "omit";
+	public static final String PREFER_MINIMAL_CONTAINER = LDP.NAMESPACE + "PreferMinimalContainer";
+	public static final String PREFER_CONTAINMENT = LDP.NAMESPACE + "PreferContainment";
+	public static final String PREFER_MEMBERSHIP = LDP.NAMESPACE + "PreferMembership";
 }

--- a/src/main/java/org/w3/ldp/testsuite/http/MediaTypes.java
+++ b/src/main/java/org/w3/ldp/testsuite/http/MediaTypes.java
@@ -2,9 +2,9 @@ package org.w3.ldp.testsuite.http;
 
 public interface MediaTypes {
 
-    public final static String TEXT_TURTLE = "text/turtle";
-    public final static String APPLICATION_RDF_XML = "application/rdf+xml";
-    public final static String APPLICATION_JSON = "application/json";
-    public final static String APPLICATION_LD_JSON = "application/ld+json";
+	public final static String TEXT_TURTLE = "text/turtle";
+	public final static String APPLICATION_RDF_XML = "application/rdf+xml";
+	public final static String APPLICATION_JSON = "application/json";
+	public final static String APPLICATION_LD_JSON = "application/ld+json";
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/mapper/RdfObjectMapper.java
+++ b/src/main/java/org/w3/ldp/testsuite/mapper/RdfObjectMapper.java
@@ -14,48 +14,48 @@ import com.jayway.restassured.mapper.ObjectMapperSerializationContext;
 
 public class RdfObjectMapper implements ObjectMapper {
 
-    private String baseURI;
+	private String baseURI;
 
-    public RdfObjectMapper() {
-        this.baseURI = "";
-    }
+	public RdfObjectMapper() {
+		this.baseURI = "";
+	}
 
-    public RdfObjectMapper(String baseURI) {
-        this.baseURI = baseURI;
-    }
+	public RdfObjectMapper(String baseURI) {
+		this.baseURI = baseURI;
+	}
 
-    private String getLang(String mediaType) {
-        if (MediaTypes.TEXT_TURTLE.equals(mediaType)) {
-            return "TURTLE";
-        } else if (MediaTypes.APPLICATION_RDF_XML.equals(mediaType)) {
-            return "RDF/XML";
-        } else if (MediaTypes.APPLICATION_JSON.equals(mediaType) ||
-                MediaTypes.APPLICATION_LD_JSON.equals(mediaType)) {
-            return "JSON-LD";
-        }
+	private String getLang(String mediaType) {
+		if (MediaTypes.TEXT_TURTLE.equals(mediaType)) {
+			return "TURTLE";
+		} else if (MediaTypes.APPLICATION_RDF_XML.equals(mediaType)) {
+			return "RDF/XML";
+		} else if (MediaTypes.APPLICATION_JSON.equals(mediaType) ||
+				MediaTypes.APPLICATION_LD_JSON.equals(mediaType)) {
+			return "JSON-LD";
+		}
 
-        throw new IllegalArgumentException("Unsupported media type: " + mediaType);
-    }
+		throw new IllegalArgumentException("Unsupported media type: " + mediaType);
+	}
 
-    @Override
-    public Object deserialize(ObjectMapperDeserializationContext context) {
-        InputStream input = context.getDataToDeserialize().asInputStream();
-        Model m = ModelFactory.createDefaultModel();
-        m.read(input, baseURI, getLang(context.getContentType()));
-        return m;
-    }
+	@Override
+	public Object deserialize(ObjectMapperDeserializationContext context) {
+		InputStream input = context.getDataToDeserialize().asInputStream();
+		Model m = ModelFactory.createDefaultModel();
+		m.read(input, baseURI, getLang(context.getContentType()));
+		return m;
+	}
 
-    @Override
-    public Object serialize(ObjectMapperSerializationContext context) {
-        Model model = context.getObjectToSerializeAs(Model.class);
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
+	@Override
+	public Object serialize(ObjectMapperSerializationContext context) {
+		Model model = context.getObjectToSerializeAs(Model.class);
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        String lang = getLang(context.getContentType());
-        RDFWriter rdfWriter = model.getWriter(lang);
-        rdfWriter.setProperty("relativeURIs", "same-document");
-        rdfWriter.setProperty("allowBadURIs", "true");
-        rdfWriter.write(model, out, baseURI);
+		String lang = getLang(context.getContentType());
+		RDFWriter rdfWriter = model.getWriter(lang);
+		rdfWriter.setProperty("relativeURIs", "same-document");
+		rdfWriter.setProperty("allowBadURIs", "true");
+		rdfWriter.write(model, out, baseURI);
 
-        return out.toByteArray();
-    }
+		return out.toByteArray();
+	}
 }

--- a/src/main/java/org/w3/ldp/testsuite/matcher/HeaderMatchers.java
+++ b/src/main/java/org/w3/ldp/testsuite/matcher/HeaderMatchers.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *	   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,83 +31,83 @@ import javax.ws.rs.core.Link;
  * Matcher collection to work with HttpHeaders.
  */
 public class HeaderMatchers {
-    
-    /**
-     * Regular expression matching valid ETag values.
-     * 
-     * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19">HTTP 1.1: Section 14.19 - ETag</a>
-     */
-    public final static String ETAG_REGEX = "^(W/)?\"([^\"]|\\\\\")*\"$";
 
-    public static Matcher<String> headerPresent() {
-        return new BaseMatcher<String>() {
-            @Override
-            public boolean matches(Object item) {
-                return item != null && StringUtils.isNotBlank(item.toString());
-            }
+	/**
+	 * Regular expression matching valid ETag values.
+	 *
+	 * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19">HTTP 1.1: Section 14.19 - ETag</a>
+	 */
+	public final static String ETAG_REGEX = "^(W/)?\"([^\"]|\\\\\")*\"$";
 
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("set");
-            }
-        };
-    }
+	public static Matcher<String> headerPresent() {
+		return new BaseMatcher<String>() {
+			@Override
+			public boolean matches(Object item) {
+				return item != null && StringUtils.isNotBlank(item.toString());
+			}
 
-    public static Matcher<String> headerNotPresent() {
-        return new BaseMatcher<String>() {
-            @Override
-            public boolean matches(Object item) {
-                return item == null || StringUtils.isBlank(item.toString());
-            }
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("set");
+			}
+		};
+	}
 
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("absent or empty");
-            }
-        };
-    }
+	public static Matcher<String> headerNotPresent() {
+		return new BaseMatcher<String>() {
+			@Override
+			public boolean matches(Object item) {
+				return item == null || StringUtils.isBlank(item.toString());
+			}
 
-    public static Matcher<String> isLink(String uri, String rel) {
-        final Link expected = Link.fromUri(uri).rel(rel).build();
-        return new CustomTypeSafeMatcher<String>(String.format("a Link-Header to <%s> with rel='%s'", uri, rel)) {
-            @Override
-            protected boolean matchesSafely(String item) {
-                return expected.equals(new LinkDelegate().fromString(item));
-            }
-        };
-    }
- 
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("absent or empty");
+			}
+		};
+	}
 
-    public static Matcher<String> isValidEntityTag() {
-        return new CustomTypeSafeMatcher<String>("a valid EntityTag value as defined in RFC2616 section 14.19 (did you quote the value?)") {
-            /**
-             * Checks that the ETag value is present and valid as defined in RFC2616
-             * 
-             * @param item
-             *            the header value
-             * @return true only if the ETag is valid
-             * 
-             * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19">HTTP 1.1: Section 14.19 - ETag</a>
-             */
-            @Override
-            protected boolean matchesSafely(String item) {
-                return item.trim().matches(ETAG_REGEX);
-            }
-        };
-    }
-    
-    /**
-     * Matcher testing a Content-Type response header's compatibility with
-     * JSON-LD (expects application/ld+json or application/json).
-     * 
-     * @return the matcher
-     */
-    public static Matcher<String> isJsonLdCompatibleContentType() {
-        return new CustomTypeSafeMatcher<String>("application/ld+json or application/json") {
-            @Override
-            protected boolean matchesSafely(String item) {
-                return item.equals(MediaTypes.APPLICATION_LD_JSON) || item.equals(MediaTypes.APPLICATION_JSON);
-            }
-        }; 
-    }
+	public static Matcher<String> isLink(String uri, String rel) {
+		final Link expected = Link.fromUri(uri).rel(rel).build();
+		return new CustomTypeSafeMatcher<String>(String.format("a Link-Header to <%s> with rel='%s'", uri, rel)) {
+			@Override
+			protected boolean matchesSafely(String item) {
+				return expected.equals(new LinkDelegate().fromString(item));
+			}
+		};
+	}
+
+
+	public static Matcher<String> isValidEntityTag() {
+		return new CustomTypeSafeMatcher<String>("a valid EntityTag value as defined in RFC2616 section 14.19 (did you quote the value?)") {
+			/**
+			 * Checks that the ETag value is present and valid as defined in RFC2616
+			 *
+			 * @param item
+			 *			  the header value
+			 * @return true only if the ETag is valid
+			 *
+			 * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19">HTTP 1.1: Section 14.19 - ETag</a>
+			 */
+			@Override
+			protected boolean matchesSafely(String item) {
+				return item.trim().matches(ETAG_REGEX);
+			}
+		};
+	}
+
+	/**
+	 * Matcher testing a Content-Type response header's compatibility with
+	 * JSON-LD (expects application/ld+json or application/json).
+	 *
+	 * @return the matcher
+	 */
+	public static Matcher<String> isJsonLdCompatibleContentType() {
+		return new CustomTypeSafeMatcher<String>("application/ld+json or application/json") {
+			@Override
+			protected boolean matchesSafely(String item) {
+				return item.equals(MediaTypes.APPLICATION_LD_JSON) || item.equals(MediaTypes.APPLICATION_JSON);
+			}
+		};
+	}
 }

--- a/src/main/java/org/w3/ldp/testsuite/matcher/HttpStatusNotFoundOrGoneMatcher.java
+++ b/src/main/java/org/w3/ldp/testsuite/matcher/HttpStatusNotFoundOrGoneMatcher.java
@@ -8,18 +8,18 @@ import org.hamcrest.TypeSafeMatcher;
 
 public class HttpStatusNotFoundOrGoneMatcher extends TypeSafeMatcher<Integer> {
 
-    @Override
-    public void describeTo(Description d) {
-        d.appendText("404 Not Found or 410 Gone");
-    }
+	@Override
+	public void describeTo(Description d) {
+		d.appendText("404 Not Found or 410 Gone");
+	}
 
-    @Override
-    protected boolean matchesSafely(Integer status) {
-        return status == HttpStatus.SC_NOT_FOUND || status == HttpStatus.SC_GONE;
-    }
+	@Override
+	protected boolean matchesSafely(Integer status) {
+		return status == HttpStatus.SC_NOT_FOUND || status == HttpStatus.SC_GONE;
+	}
 
-    @Factory
-    public static Matcher<Integer> isNotFoundOrGone() {
-        return new HttpStatusNotFoundOrGoneMatcher();
-    }
+	@Factory
+	public static Matcher<Integer> isNotFoundOrGone() {
+		return new HttpStatusNotFoundOrGoneMatcher();
+	}
 }

--- a/src/main/java/org/w3/ldp/testsuite/matcher/HttpStatusSuccessMatcher.java
+++ b/src/main/java/org/w3/ldp/testsuite/matcher/HttpStatusSuccessMatcher.java
@@ -7,19 +7,19 @@ import org.hamcrest.TypeSafeMatcher;
 
 public class HttpStatusSuccessMatcher extends TypeSafeMatcher<Integer> {
 
-    @Override
-    public void describeTo(Description d) {
-        d.appendText("between 200 and 209");
-    }
+	@Override
+	public void describeTo(Description d) {
+		d.appendText("between 200 and 209");
+	}
 
-    @Override
-    protected boolean matchesSafely(Integer status) {
-        return status >= 200 && status <= 209;
-    }
+	@Override
+	protected boolean matchesSafely(Integer status) {
+		return status >= 200 && status <= 209;
+	}
 
-    @Factory
-    public static Matcher<Integer> isSuccessful() {
-        return new HttpStatusSuccessMatcher();
-    }
+	@Factory
+	public static Matcher<Integer> isSuccessful() {
+		return new HttpStatusSuccessMatcher();
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpHtmlReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpHtmlReporter.java
@@ -51,29 +51,29 @@ public class LdpHtmlReporter implements IReporter {
 	private IResultMap failedTests;
 	private IResultMap skippedTests;
 
-    private HtmlCanvas html;
+	private HtmlCanvas html;
 
 	private static StringWriter graphs = new StringWriter();
 
-    public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites,
-                               String outputDirectory) {
-        try {
-            html = new HtmlCanvas();
-            html.html().head();
+	public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites,
+							   String outputDirectory) {
+		try {
+			html = new HtmlCanvas();
+			html.html().head();
 
-            writeCss();
-            html._head().body().title().content(LdpTestSuite.NAME + " Report");
-            html.h1().content(LdpTestSuite.NAME + " Summary");
+			writeCss();
+			html._head().body().title().content(LdpTestSuite.NAME + " Report");
+			html.h1().content(LdpTestSuite.NAME + " Summary");
 
 			html.h2().content("Overall Coverage Bar Charts");
 			html.div(class_("barChart").id("overallChart"))._div(); // svg chart
 			html.div(class_("barChart").id("resourcesChart"))._div();
 
-            generateOverallSummaryReport(suites, "summary");
-            displayGroupsInfo(suites);
-            displayMethodsSummary(suites);
-            toTop();
-            generateMethodDetails(suites);
+			generateOverallSummaryReport(suites, "summary");
+			displayGroupsInfo(suites);
+			displayMethodsSummary(suites);
+			toTop();
+			generateMethodDetails(suites);
 
 			html.script().content(
 					StringResource.get("/raphael/raphael-min.js"), NO_ESCAPE);
@@ -84,339 +84,339 @@ public class LdpHtmlReporter implements IReporter {
 			writeOverallBarChart();
 			writeResourcesBarChart();
 			html.write(graphs.toString(), NO_ESCAPE);
-            html._body()._html();
+			html._body()._html();
 
-            // send html to a file
-            createWriter("report", html.toHtml());
+			// send html to a file
+			createWriter("report", html.toHtml());
 
 			Files.copy(getClass().getResourceAsStream("/testng-reports.css"),
 					new File(outputDirectory, "testng-reports.css").toPath(),
 					StandardCopyOption.REPLACE_EXISTING);
 
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
 
-    private void writeCss() throws IOException {
+	private void writeCss() throws IOException {
 
-        html.style().write(StringResource.get("reportStyle.css"), NO_ESCAPE)
-                ._style();
-    }
+		html.style().write(StringResource.get("reportStyle.css"), NO_ESCAPE)
+				._style();
+	}
 
-    private void createWriter(String directory, String output) {
-        BufferedWriter writer = null;
-        new File(directory).mkdirs();
-        try {
-            writer = new BufferedWriter(new FileWriter(directory
-                    + "/ldp-testsuite-execution-report.html"));
-            writer.write(output);
+	private void createWriter(String directory, String output) {
+		BufferedWriter writer = null;
+		new File(directory).mkdirs();
+		try {
+			writer = new BufferedWriter(new FileWriter(directory
+					+ "/ldp-testsuite-execution-report.html"));
+			writer.write(output);
 
-        } catch (IOException e) {
-        } finally {
-            try {
-                if (writer != null)
-                    writer.close();
-            } catch (IOException e) {
-            }
-        }
-    }
+		} catch (IOException e) {
+		} finally {
+			try {
+				if (writer != null)
+					writer.close();
+			} catch (IOException e) {
+			}
+		}
+	}
 
-    private void generateOverallSummaryReport(List<ISuite> suites, String id)
-            throws IOException {
-        html.table(class_("summary"));
-        Date date = new Date();
-        for (ISuite suite : suites) {
-            // Getting the results for the said suite
-            Map<String, ISuiteResult> suiteResults = suite.getResults();
+	private void generateOverallSummaryReport(List<ISuite> suites, String id)
+			throws IOException {
+		html.table(class_("summary"));
+		Date date = new Date();
+		for (ISuite suite : suites) {
+			// Getting the results for the said suite
+			Map<String, ISuiteResult> suiteResults = suite.getResults();
 
-            for (ISuiteResult sr : suiteResults.values()) {
+			for (ISuiteResult sr : suiteResults.values()) {
 
-                ITestContext tc = sr.getTestContext();
+				ITestContext tc = sr.getTestContext();
 
 				passedTests = tc.getPassedTests();
 				failedTests = tc.getFailedTests();
 				skippedTests = tc.getSkippedTests();
 
-                Iterator<ITestResult> passedResults = tc.getPassedTests()
-                        .getAllResults().iterator();
-                while (passedResults.hasNext()) {
-                    ITestResult result = passedResults.next();
-                    if (result.getAttribute("warn") != null)
-                        warned++;
+				Iterator<ITestResult> passedResults = tc.getPassedTests()
+						.getAllResults().iterator();
+				while (passedResults.hasNext()) {
+					ITestResult result = passedResults.next();
+					if (result.getAttribute("warn") != null)
+						warned++;
 
-                    try {
-                        Method m = result.getMethod().getConstructorOrMethod()
-                                .getMethod();
-                        String[] groups = m.getAnnotation(Test.class).groups();
-                        for (int i = 0; i < groups.length; i++) {
-                            if (groups[i].equals("MUST"))
-                                mustPass++;
-                            if (groups[i].equals("MAY"))
-                                mayPass++;
-                            if (groups[i].equals("SHOULD"))
-                                shouldPass++;
+					try {
+						Method m = result.getMethod().getConstructorOrMethod()
+								.getMethod();
+						String[] groups = m.getAnnotation(Test.class).groups();
+						for (int i = 0; i < groups.length; i++) {
+							if (groups[i].equals("MUST"))
+								mustPass++;
+							if (groups[i].equals("MAY"))
+								mayPass++;
+							if (groups[i].equals("SHOULD"))
+								shouldPass++;
 
-                        }
-                    } catch (SecurityException e) {
-                        e.printStackTrace();
-                    }
+						}
+					} catch (SecurityException e) {
+						e.printStackTrace();
+					}
 
-                }
-                Iterator<ITestResult> failedResults = tc.getFailedTests()
-                        .getAllResults().iterator();
-                while (failedResults.hasNext()) {
-                    ITestResult result = failedResults.next();
-                    if (result.getAttribute("warn") != null)
-                        warned++;
+				}
+				Iterator<ITestResult> failedResults = tc.getFailedTests()
+						.getAllResults().iterator();
+				while (failedResults.hasNext()) {
+					ITestResult result = failedResults.next();
+					if (result.getAttribute("warn") != null)
+						warned++;
 
-                    try {
-                        // System.out.println(warning.getMethod().getConstructorOrMethod().getMethod().toString());
-                        Method m = result.getMethod().getConstructorOrMethod()
-                                .getMethod();
-                        String[] groups = m.getAnnotation(Test.class).groups();
-                        for (int i = 0; i < groups.length; i++) {
-                            if (groups[i].equals("MUST"))
-                                mustFailed++;
+					try {
+						// System.out.println(warning.getMethod().getConstructorOrMethod().getMethod().toString());
+						Method m = result.getMethod().getConstructorOrMethod()
+								.getMethod();
+						String[] groups = m.getAnnotation(Test.class).groups();
+						for (int i = 0; i < groups.length; i++) {
+							if (groups[i].equals("MUST"))
+								mustFailed++;
 							if (groups[i].equals("SHOULD"))
 								shouldFailed++;
 							if (groups[i].equals("MAY"))
 								mayFailed++;
-                        }
-                    } catch (SecurityException e) {
-                        e.printStackTrace();
-                    }
+						}
+					} catch (SecurityException e) {
+						e.printStackTrace();
+					}
 
-                }
-                passed = tc.getPassedTests().getAllResults().size();
-                failed = tc.getFailedTests().getAllResults().size();
-                skipped = tc.getSkippedTests().getAllResults().size();
-            }
-            total = passed + failed + skipped;
-            generateSummaryTableStart(date, suite.getName());
-            generateSummaryTable(passed, skipped, warned, total, mayPass,
-                    mustPass, shouldPass, mustFailed);
-            html._table();
-        }
+				}
+				passed = tc.getPassedTests().getAllResults().size();
+				failed = tc.getFailedTests().getAllResults().size();
+				skipped = tc.getSkippedTests().getAllResults().size();
+			}
+			total = passed + failed + skipped;
+			generateSummaryTableStart(date, suite.getName());
+			generateSummaryTable(passed, skipped, warned, total, mayPass,
+					mustPass, shouldPass, mustFailed);
+			html._table();
+		}
 
-    }
+	}
 
-    private void generateSummaryTableStart(Date date, String suiteName)
-            throws IOException {
-        html.tr().th().content("Test Suite Name");
-        html.th().content("Report Date");
-        html.th().content("Passed with Warnings");
-        html.th().content("Skipped Tests");
-        html.th().content("Passed (MUST)");
-        html.th().content("Passed (MAY)");
-        html.th().content("Passed (SHOULD)");
-        html.th().content("Failed (MUST)")._tr();
+	private void generateSummaryTableStart(Date date, String suiteName)
+			throws IOException {
+		html.tr().th().content("Test Suite Name");
+		html.th().content("Report Date");
+		html.th().content("Passed with Warnings");
+		html.th().content("Skipped Tests");
+		html.th().content("Passed (MUST)");
+		html.th().content("Passed (MAY)");
+		html.th().content("Passed (SHOULD)");
+		html.th().content("Failed (MUST)")._tr();
 
-        html.tr(class_("alt")).td().content(suiteName);
-        html.td().content(date.toString());
-    }
+		html.tr(class_("alt")).td().content(suiteName);
+		html.td().content(date.toString());
+	}
 
-    private void generateSummaryTable(int passed, int skipped, int warned,
-                                      int total, int may, int must, int should, int mustFailed)
-            throws IOException {
-        printCellResult(warned, total);
-        printCellResult(skipped, total);
-        printCellResult(must, total);
-        printCellResult(may, total);
-        printCellResult(should, total);
-        printCellResult(mustFailed, total);
-        html._tr();
-    }
+	private void generateSummaryTable(int passed, int skipped, int warned,
+									  int total, int may, int must, int should, int mustFailed)
+			throws IOException {
+		printCellResult(warned, total);
+		printCellResult(skipped, total);
+		printCellResult(must, total);
+		printCellResult(may, total);
+		printCellResult(should, total);
+		printCellResult(mustFailed, total);
+		html._tr();
+	}
 
-    private void printCellResult(int value, int total) throws IOException {
+	private void printCellResult(int value, int total) throws IOException {
 		if (value == 0)
-            html.td().i().write("No tests of this type called")._i()._td();
-        else {
-            DecimalFormat df = new DecimalFormat("##.##");
-            double result = (((double) value / total) * 100);
-            String finalTotal = df.format(result);
-            html.td().b().write(finalTotal + "% ")._b();
-            html.write("of the total tests (");
-            html.b().write(value + "/" + total)._b();
-            html.write(")")._td();
-        }
-    }
+			html.td().i().write("No tests of this type called")._i()._td();
+		else {
+			DecimalFormat df = new DecimalFormat("##.##");
+			double result = (((double) value / total) * 100);
+			String finalTotal = df.format(result);
+			html.td().b().write(finalTotal + "% ")._b();
+			html.write("of the total tests (");
+			html.b().write(value + "/" + total)._b();
+			html.write(")")._td();
+		}
+	}
 
-    private void displayGroupsInfo(List<ISuite> suite) throws IOException {
-        for (ISuite testSuite : suite) {
-            Map<String, ISuiteResult> tests = testSuite.getResults();
-            for (ISuiteResult results : tests.values()) {
-                ITestContext overview = results.getTestContext();
-                String[] excluded = overview.getExcludedGroups();
-                String[] included = overview.getIncludedGroups();
-                generateList(included,
-                        "Included Groups for " + testSuite.getName());
-                generateList(excluded,
-                        "Excluded Groups for " + testSuite.getName());
-            }
-        }
-    }
+	private void displayGroupsInfo(List<ISuite> suite) throws IOException {
+		for (ISuite testSuite : suite) {
+			Map<String, ISuiteResult> tests = testSuite.getResults();
+			for (ISuiteResult results : tests.values()) {
+				ITestContext overview = results.getTestContext();
+				String[] excluded = overview.getExcludedGroups();
+				String[] included = overview.getIncludedGroups();
+				generateList(included,
+						"Included Groups for " + testSuite.getName());
+				generateList(excluded,
+						"Excluded Groups for " + testSuite.getName());
+			}
+		}
+	}
 
-    private void generateList(String[] list, String title) throws IOException {
-        html.h2().write(title)._h2();
-        if (list.length == 0) {
-            html.div(style("padding-left:2em")).i()
-                    .content("No groups of this type found in the test suite")
-                    ._div();
-        } else {
-            html.ul();
-            for (String group : list) {
-                html.li().content(group);
-            }
-            html._ul();
-        }
-    }
+	private void generateList(String[] list, String title) throws IOException {
+		html.h2().write(title)._h2();
+		if (list.length == 0) {
+			html.div(style("padding-left:2em")).i()
+					.content("No groups of this type found in the test suite")
+					._div();
+		} else {
+			html.ul();
+			for (String group : list) {
+				html.li().content(group);
+			}
+			html._ul();
+		}
+	}
 
-    private void displayMethodsSummary(List<ISuite> suites) throws IOException {
-        for (ISuite suite : suites) {
-            Map<String, ISuiteResult> r = suite.getResults();
-            for (ISuiteResult r2 : r.values()) {
-                ITestContext testContext = r2.getTestContext();
-                makeMethodsList(testContext);
-            }
-        }
-    }
+	private void displayMethodsSummary(List<ISuite> suites) throws IOException {
+		for (ISuite suite : suites) {
+			Map<String, ISuiteResult> r = suite.getResults();
+			for (ISuiteResult r2 : r.values()) {
+				ITestContext testContext = r2.getTestContext();
+				makeMethodsList(testContext);
+			}
+		}
+	}
 
-    private void makeMethodsList(ITestContext testContext) throws IOException {
-        IResultMap failed = testContext.getFailedTests();
-        IResultMap passed = testContext.getPassedTests();
-        IResultMap skipped = testContext.getSkippedTests();
+	private void makeMethodsList(ITestContext testContext) throws IOException {
+		IResultMap failed = testContext.getFailedTests();
+		IResultMap passed = testContext.getPassedTests();
+		IResultMap skipped = testContext.getSkippedTests();
 
-        html.h1(class_("center")).content("Methods called");
-        html.table(class_("indented"));
-        makeMethodSummaryTable(failed, "Failed");
-        makeMethodSummaryTable(skipped, "Skipped");
-        makeMethodSummaryTable(passed, "Passed");
-        html._table();
+		html.h1(class_("center")).content("Methods called");
+		html.table(class_("indented"));
+		makeMethodSummaryTable(failed, "Failed");
+		makeMethodSummaryTable(skipped, "Skipped");
+		makeMethodSummaryTable(passed, "Passed");
+		html._table();
 
-    }
+	}
 
-    private void makeMethodSummaryTable(IResultMap tests, String title)
-            throws IOException {
-        html.tr().th(class_(title)).content(title + " Test Cases");
-        html.th(class_(title)).content("Test Class");
-        html.th(class_(title)).content("Description of Test Method")._tr();
-        for (ITestResult result : tests.getAllResults()) {
-            ITestNGMethod method = result.getMethod();
-            html.tr();
-            html.td()
-                    .a(href("#" + method.getTestClass().getName() + "_"
-                            + method.getMethodName()))
-                    .write(method.getMethodName(), NO_ESCAPE)._a()._td();
-            html.td().content(method.getTestClass().getName());
+	private void makeMethodSummaryTable(IResultMap tests, String title)
+			throws IOException {
+		html.tr().th(class_(title)).content(title + " Test Cases");
+		html.th(class_(title)).content("Test Class");
+		html.th(class_(title)).content("Description of Test Method")._tr();
+		for (ITestResult result : tests.getAllResults()) {
+			ITestNGMethod method = result.getMethod();
+			html.tr();
+			html.td()
+					.a(href("#" + method.getTestClass().getName() + "_"
+							+ method.getMethodName()))
+					.write(method.getMethodName(), NO_ESCAPE)._a()._td();
+			html.td().content(method.getTestClass().getName());
 
-            html.td().content(
-                    (method.getDescription() != null ? method.getDescription()
+			html.td().content(
+					(method.getDescription() != null ? method.getDescription()
 							: "No Description found"));
-            html._tr();
-        }
+			html._tr();
+		}
 
-    }
+	}
 
-    private void generateMethodDetails(List<ISuite> suites) throws IOException {
-        html.h1().content("Test Method Details");
-        for (ISuite suite : suites) {
-            Map<String, ISuiteResult> r = suite.getResults();
-            for (ISuiteResult r2 : r.values()) {
-                ITestContext testContext = r2.getTestContext();
+	private void generateMethodDetails(List<ISuite> suites) throws IOException {
+		html.h1().content("Test Method Details");
+		for (ISuite suite : suites) {
+			Map<String, ISuiteResult> r = suite.getResults();
+			for (ISuiteResult r2 : r.values()) {
+				ITestContext testContext = r2.getTestContext();
 
-                generateDetail(testContext.getFailedTests());
-                generateDetail(testContext.getSkippedTests());
-                generateDetail(testContext.getPassedTests());
-            }
-        }
-    }
+				generateDetail(testContext.getFailedTests());
+				generateDetail(testContext.getSkippedTests());
+				generateDetail(testContext.getPassedTests());
+			}
+		}
+	}
 
-    private void generateDetail(IResultMap tests) throws IOException {
-        for (ITestResult m : tests.getAllResults()) {
-            ITestNGMethod method = m.getMethod();
-            html.h2()
-                    .a(id(m.getTestClass().getName() + "_"
-                            + method.getMethodName()))
-                    .write(m.getTestClass().getName() + ": "
-                            + method.getMethodName())._a()._h2();
-            getAdditionalInfo(m, method);
-            html.p(class_("indented"))
-                    .b()
-                    .write("Description: ")
-                    ._b()
-                    .write((method.getDescription() != null ? method
-                            .getDescription()
-                            : "No description for this test method found"))
-                    ._p();
-            String groups = "";
-            for (String group : method.getGroups()) {
-                groups += group + " ";
-            }
-            html.p(class_("indented")).b().write("Specifications: ")._b()
-                    .write(groups)._p();
+	private void generateDetail(IResultMap tests) throws IOException {
+		for (ITestResult m : tests.getAllResults()) {
+			ITestNGMethod method = m.getMethod();
+			html.h2()
+					.a(id(m.getTestClass().getName() + "_"
+							+ method.getMethodName()))
+					.write(m.getTestClass().getName() + ": "
+							+ method.getMethodName())._a()._h2();
+			getAdditionalInfo(m, method);
+			html.p(class_("indented"))
+					.b()
+					.write("Description: ")
+					._b()
+					.write((method.getDescription() != null ? method
+							.getDescription()
+							: "No description for this test method found"))
+					._p();
+			String groups = "";
+			for (String group : method.getGroups()) {
+				groups += group + " ";
+			}
+			html.p(class_("indented")).b().write("Specifications: ")._b()
+					.write(groups)._p();
 
-            toTop();
-        }
+			toTop();
+		}
 
-    }
+	}
 
-    private void getAdditionalInfo(ITestResult m, ITestNGMethod method)
-            throws IOException {
-        if (m.getThrowable() != null) {
-            Throwable thrown = m.getThrowable();
-            String exception = thrown.getClass().getName();
-            if (exception.contains("Skip")) {
-                createSkipExceptionTable(thrown);
-            } else {
-                createThrownTable(thrown);
-            }
-        }
+	private void getAdditionalInfo(ITestResult m, ITestNGMethod method)
+			throws IOException {
+		if (m.getThrowable() != null) {
+			Throwable thrown = m.getThrowable();
+			String exception = thrown.getClass().getName();
+			if (exception.contains("Skip")) {
+				createSkipExceptionTable(thrown);
+			} else {
+				createThrownTable(thrown);
+			}
+		}
 
-        if (m.getParameters() != null && m.getParameters().length != 0) {
-            Object[] params = m.getParameters();
-            String parameters = "";
-            for (Object p : params) {
-                if (p != null)
-                    parameters += p.toString() + " ";
-            }
-            html.p(class_("indented")).b().write("Parameters: ")._b()
-                    .write(parameters)._p();
-        }
+		if (m.getParameters() != null && m.getParameters().length != 0) {
+			Object[] params = m.getParameters();
+			String parameters = "";
+			for (Object p : params) {
+				if (p != null)
+					parameters += p.toString() + " ";
+			}
+			html.p(class_("indented")).b().write("Parameters: ")._b()
+					.write(parameters)._p();
+		}
 
-        String reference = "";
-        if (m.getMethod().getConstructorOrMethod().getMethod()
-                .getAnnotation(SpecTest.class) != null) {
-            reference = m.getMethod().getConstructorOrMethod().getMethod()
-                    .getAnnotation(SpecTest.class).specRefUri();
-            html.p(class_("indented")).b().write("Reference URI: ")._b()
-                    .a(href(reference)).write(reference)._a()._p();
-        }
+		String reference = "";
+		if (m.getMethod().getConstructorOrMethod().getMethod()
+				.getAnnotation(SpecTest.class) != null) {
+			reference = m.getMethod().getConstructorOrMethod().getMethod()
+					.getAnnotation(SpecTest.class).specRefUri();
+			html.p(class_("indented")).b().write("Reference URI: ")._b()
+					.a(href(reference)).write(reference)._a()._p();
+		}
 
-    }
+	}
 
-    private void createSkipExceptionTable(Throwable thrown) throws IOException {
-        html.table(class_("indented"));
-        html.tr(class_("center")).th(class_("Skipped"))
-                .content("[SKIPPED TEST]")._tr();
-        html.td().content(thrown.getMessage());
-        html._table();
+	private void createSkipExceptionTable(Throwable thrown) throws IOException {
+		html.table(class_("indented"));
+		html.tr(class_("center")).th(class_("Skipped"))
+				.content("[SKIPPED TEST]")._tr();
+		html.td().content(thrown.getMessage());
+		html._table();
 
-    }
+	}
 
-    private void createThrownTable(Throwable thrown) throws IOException {
-        html.table(class_("indented"));
-        html.tr(class_("center")).th(class_("Failed")).content("[FAILED TEST]")
-                ._tr();
-        html.td(class_("throw")).content(Utils.stackTrace(thrown, true)[0]);
+	private void createThrownTable(Throwable thrown) throws IOException {
+		html.table(class_("indented"));
+		html.tr(class_("center")).th(class_("Failed")).content("[FAILED TEST]")
+				._tr();
+		html.td(class_("throw")).content(Utils.stackTrace(thrown, true)[0]);
 
-        html._table();
+		html._table();
 
-    }
+	}
 
-    private void toTop() throws IOException {
-        html.p(class_("totop")).a(href("#top")).content("Back to Top")._p();
-    }
+	private void toTop() throws IOException {
+		html.p(class_("totop")).a(href("#top")).content("Back to Top")._p();
+	}
 	private void writeOverallBarChart() throws IOException {
 		graphs.write("<script>");
 		graphs.write("Event.observe(window, 'load', function() {");

--- a/src/main/java/org/w3/ldp/testsuite/test/BasicContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/BasicContainerTest.java
@@ -22,70 +22,71 @@ import static org.testng.Assert.assertTrue;
 
 public class BasicContainerTest extends CommonContainerTest {
 
-    private String basicContainer;
+	private String basicContainer;
 
-    @Parameters({"basicContainer", "auth"})
-    public BasicContainerTest(@Optional String basicContainer, @Optional String auth) throws IOException {
-        super(auth);
-        this.basicContainer = basicContainer;
-    }
+	@Parameters({"basicContainer", "auth"})
+	public BasicContainerTest(@Optional String basicContainer, @Optional String auth) throws IOException {
+		super(auth);
+		this.basicContainer = basicContainer;
+	}
 
-    @BeforeClass(alwaysRun = true)
-    public void hasBasicContainer() {
-        if (basicContainer == null) {
-            throw new SkipException("No basicContainer parameter provided in testng.xml. Skipping ldp:basicContainer tests.");
-        }
-    }
+	@BeforeClass(alwaysRun = true)
+	public void hasBasicContainer() {
+		if (basicContainer == null) {
+			throw new SkipException(
+					"No basicContainer parameter provided in testng.xml. Skipping ldp:basicContainer tests.");
+		}
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers exposing LDPCs MUST advertise their "
-                    + "LDP support by exposing a HTTP Link header with a "
-                    + "target URI matching the type of container (see below) "
-                    + "the server supports, and a link relation type of type "
-                    + "(that is, rel='type') in all responses to requests made "
-                    + "to the LDPC's HTTP Request-URI.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testContainerSupportsHttpLinkHeader() {
-        Response response = buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
-                .expect().statusCode(HttpStatus.SC_OK).when()
-                .get(basicContainer);
-        assertTrue(
-                containsLinkHeader(LDP.BasicContainer.stringValue(), LINK_REL_TYPE,
-                        response),
-                "LDP BasicContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <"
-                        + LDP.BasicContainer.stringValue() + "> and rel='type'"
-        );
-    }
+	@Test(
+			groups = {MUST},
+			description = "LDP servers exposing LDPCs MUST advertise their "
+					+ "LDP support by exposing a HTTP Link header with a "
+					+ "target URI matching the type of container (see below) "
+					+ "the server supports, and a link relation type of type "
+					+ "(that is, rel='type') in all responses to requests made "
+					+ "to the LDPC's HTTP Request-URI.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testContainerSupportsHttpLinkHeader() {
+		Response response = buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
+				.expect().statusCode(HttpStatus.SC_OK).when()
+				.get(basicContainer);
+		assertTrue(
+				containsLinkHeader(LDP.BasicContainer.stringValue(), LINK_REL_TYPE,
+						response),
+				"LDP BasicContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <"
+						+ LDP.BasicContainer.stringValue() + "> and rel='type'"
+		);
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "Each LDP Basic Container MUST also be a "
-                    + "conforming LDP Container in section 5.2 Container "
-                    + "along the following restrictions in this section.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpbc-are-ldpcs",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testContainerTypeIsBasicContainer() {
-        // FIXME: We're just testing the RDF type here. We're not really testing
-        // the requirement.
-        Model containerModel = getAsModel(basicContainer);
-        Resource container = containerModel.getResource(basicContainer);
-        assertTrue(
-                container.hasProperty(RDF.type,
-                        containerModel.createResource(LDP.BasicContainer.stringValue())),
-                "Could not locate LDP BasicContainer rdf:type for <"
-                        + basicContainer + ">"
-        );
-    }
+	@Test(
+			groups = {MUST},
+			description = "Each LDP Basic Container MUST also be a "
+					+ "conforming LDP Container in section 5.2 Container "
+					+ "along the following restrictions in this section.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpbc-are-ldpcs",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testContainerTypeIsBasicContainer() {
+		// FIXME: We're just testing the RDF type here. We're not really testing
+		// the requirement.
+		Model containerModel = getAsModel(basicContainer);
+		Resource container = containerModel.getResource(basicContainer);
+		assertTrue(
+				container.hasProperty(RDF.type,
+						containerModel.createResource(LDP.BasicContainer.stringValue())),
+				"Could not locate LDP BasicContainer rdf:type for <"
+						+ basicContainer + ">"
+		);
+	}
 
-    @Override
-    protected String getResourceUri() {
-        return basicContainer;
-    }
+	@Override
+	protected String getResourceUri() {
+		return basicContainer;
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
@@ -44,776 +44,777 @@ import com.jayway.restassured.specification.RequestSpecification;
  */
 public abstract class CommonContainerTest extends RdfSourceTest {
 
-    public static final String MSG_LOC_NOTFOUND = "Location header missing after POST create.";
-    public static final String MSG_MBRRES_NOTFOUND = "Unable to locate object in triple with predicate ldp:membershipResource.";
-    public static final String MSG_PREFERENCE_NOT_APPLIED = "Server did not return Preference-Applied: return=representation response header";
-
-    @Parameters("auth")
-    public CommonContainerTest(@Optional String auth) throws IOException {
-        super(auth);
-    }
-
-    @Test(
-            groups = {MAY},
-            description = "LDP servers MAY choose to allow the creation of new "
-                    + "resources using HTTP PUT.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-create",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPutToCreate() {
-        String location = putToCreate();
-        buildBaseRequestSpecification().delete(location);
-    }
-
-    @Test(
-            enabled = false,
-            groups = {MUST},
-            description = "LDP servers MUST assign the default base-URI "
-                    + "for [RFC3987] relative-URI resolution to be the HTTP "
-                    + "Request-URI when the resource already exists, and to "
-                    + "the URI of the created resource when the request results "
-                    + "in the creation of a new resource.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-defbaseuri",
-            testMethod = METHOD.NOT_IMPLEMENTED,
-            approval = STATUS.WG_PENDING)
-    public void testRelativeUriResolutionPost() {
-        // TODO: Impl testRelativeUriResolutionPost
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDPC representations SHOULD NOT use RDF container "
-                    + "types rdf:Bag, rdf:Seq or rdf:List.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-nordfcontainertypes",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testNoRdfBagSeqOrList() {
-        Model containerModel = getAsModel(getResourceUri());
-        assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.Bag)
-                .hasNext(), "LDPC representations should not use rdf:Bag");
-        assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.Seq)
-                .hasNext(), "LDPC representations should not use rdf:Seq");
-        assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.List).hasNext(),
-                "LDPC representations should not use rdf:List"
-        );
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers SHOULD respect all of a client's LDP-defined "
-                    + "hints, for example which subsets of LDP-defined state the "
-                    + "client is interested in processing, to influence the set of "
-                    + "triples returned in representations of an LDPC, particularly for "
-                    + "large LDPCs. See also [LDP-PAGING].")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-prefer",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testPreferContainmentTriples() {
-        Response response;
-        Model model;
-        String containerUri = getResourceUri();
-        
-        // Ask for containment triples.
-        response = buildBaseRequestSpecification()
-                    .header(ACCEPT, TEXT_TURTLE)
-                    .header(PREFER, include(PREFER_CONTAINMENT)) // request all containment triples
-                .expect()
-                    .statusCode(isSuccessful())
-                .when()
-                    .get(containerUri);
-        model = response.as(Model.class, new RdfObjectMapper(containerUri));
-
-        assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
-
-        // Assumes the container is not empty.
-        assertTrue(model.contains(model.getResource(containerUri), model.createProperty(LDP.contains.stringValue())),
-                "Container does not have containment triples");
-        
-        // Ask for a minimal container.
-        response = buildBaseRequestSpecification()
-                    .header(ACCEPT, TEXT_TURTLE)
-                    .header(PREFER, include(PREFER_MINIMAL_CONTAINER)) // request no containment triples
-                .expect()
-                    .statusCode(isSuccessful())
-                .when()
-                    .get(containerUri);
-        model = response.as(Model.class, new RdfObjectMapper(containerUri));
-
-        assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
-        assertFalse(model.contains(model.getResource(containerUri), model.createProperty(LDP.contains.stringValue())),
-                "Container has containment triples when minimal container was requested");
-        
-        // Ask to omit containment triples.
-        response = buildBaseRequestSpecification()
-                    .header(ACCEPT, TEXT_TURTLE)
-                    .header(PREFER, omit(PREFER_CONTAINMENT)) // request no containment triples
-                .expect()
-                    .statusCode(isSuccessful())
-                .when()
-                    .get(containerUri);
-        model = response.as(Model.class, new RdfObjectMapper(containerUri));
-
-        assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
-
-        // Assumes the container is not empty.
-        assertFalse(model.contains(model.getResource(containerUri), model.createProperty(LDP.contains.stringValue())),
-                "Container has containment triples when client requested server omit them");
-    }
-    
-    @Test(
-            groups = {SHOULD},
-            description = "LDPC clients SHOULD create member resources by "
-                    + "submitting a representation as the entity body of the "
-                    + "HTTP POST to a known LDPC.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-created201",
-            testMethod = METHOD.CLIENT_ONLY,
-            approval = STATUS.WG_APPROVED)
-    public void testClientPostToCreate() {
-        throw new SkipClientTestException();
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "If the resource was created successfully, LDP servers MUST "
-                    + "respond with status code 201 (Created) and the Location "
-                    + "header set to the new resource’s URL. Clients shall not "
-                    + "expect any representation in the response entity body on "
-                    + "a 201 (Created) response.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-created201",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPostResponseStatusAndLocation() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Model model = postContent();
-        Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
-                .body(model, new RdfObjectMapper()).expect()
-                .statusCode(HttpStatus.SC_CREATED).when()
-                .post(getResourceUri());
-
-        String location = postResponse.getHeader(LOCATION);
-        assertNotNull(location, MSG_LOC_NOTFOUND);
-
-        buildBaseRequestSpecification().delete(location);
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "When a successful HTTP POST request to an LDPC results "
-                    + "in the creation of an LDPR, a containment triple MUST be "
-                    + "added to the state of LDPC.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createdmbr-contains",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPostContainer() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Model model = postContent();
-        String containerUri = getResourceUri();
-        Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
-                .body(model, new RdfObjectMapper()).expect()
-                .statusCode(HttpStatus.SC_CREATED).when()
-                .post(getResourceUri());
-
-        String location = postResponse.getHeader(LOCATION);
-        assertNotNull(location, MSG_LOC_NOTFOUND);
-
-        Model containerModel = getAsModel(containerUri);
-        Resource container = containerModel.getResource(containerUri);
-
-        assertTrue(
-                container.hasProperty(containerModel
-                                .createProperty(LDP.contains.stringValue()),
-                        containerModel.getResource(location)
-                ),
-                "Container <"
-                        + containerUri
-                        + "> does not have a containment triple for newly created resource <"
-                        + location + ">."
-        );
-
-        buildBaseRequestSpecification().delete(location);
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "LDP servers that successfully create a resource from a "
-                    + "RDF representation in the request entity body MUST honor the "
-                    + "client's requested interaction model(s). The created resource "
-                    + "can be thought of as an RDF named graph [rdf11-concepts]. If any "
-                    + "model cannot be honored, the server MUST fail the request.")
-    @Parameters("containerAsResource")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createrdf",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testRequestedInteractionModelCreateNotAllowed(@Optional String containerAsResource) {
-        if (containerAsResource == null)
-            throw new SkipException("containerAsResource is null");
-
-        Model model = postContent();
-
-        // If create is successful, then not acting like a plain ole resource
-        Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
-                .body(model, new RdfObjectMapper())
-                .post(containerAsResource);
-
-        // Cleanup if it actually created something
-        String location = postResponse.getHeader(LOCATION);
-        if (postResponse.statusCode() == HttpStatus.SC_CREATED && location !=null)
-            buildBaseRequestSpecification().delete(location);
-
-        assertNotEquals(postResponse.statusCode(), HttpStatus.SC_CREATED, "Resources with interaction model of only ldp:Resources shouldn't allow container POST-create behavior.");
-        
-        // TODO: Possibly parse 'Allow' header to see if POST is wrongly listed
-    }
-    
-    @Test(
-            groups = {MUST},
-            description = "LDP servers that successfully create a resource from a "
-                    + "RDF representation in the request entity body MUST honor the "
-                    + "client's requested interaction model(s). The created resource "
-                    + "can be thought of as an RDF named graph [rdf11-concepts]. If any "
-                    + "model cannot be honored, the server MUST fail the request.")
-    @Parameters("containerAsResource")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createrdf",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testRequestedInteractionModelHeaders(@Optional String containerAsResource) {
-        if (containerAsResource == null)
-            throw new SkipException("containerAsResource is null");
-
-        // Ensure we don't get back any of the container types in the rel='type' Link header
-        Response response = buildBaseRequestSpecification().expect().statusCode(HttpStatus.SC_OK)
-                .options(containerAsResource);
-        assertFalse(
-                containsLinkHeader(LDP.BasicContainer.stringValue(), LINK_REL_TYPE, response) ||
-                containsLinkHeader(LDP.DirectContainer.stringValue(), LINK_REL_TYPE, response) ||
-                containsLinkHeader(LDP.IndirectContainer.stringValue(), LINK_REL_TYPE, response),
-                "Resource wrongly advertising itself as a rel='type' of one of the container types."
-        );
-        
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "LDP servers MUST accept a request entity body with a "
-                    + "request header of Content-Type with value of text/turtle [turtle].")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-turtle",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testAcceptTurtle() {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Model model = postContent();
-        Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
-                .body(model, new RdfObjectMapper()).expect()
-                .statusCode(HttpStatus.SC_CREATED).when()
-                .post(getResourceUri());
-
-        // Delete the resource to clean up.
-        String location = postResponse.getHeader(LOCATION);
-        if (location != null) {
-            buildBaseRequestSpecification().delete(location);
-        }
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers SHOULD use the Content-Type request header to "
-                    + "determine the representation format when the request has an "
-                    + "entity body.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-contenttype",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testContentTypeHeader() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        // POST Turtle content with a bad Content-Type request header to see what happens.
-        Model toPost = postContent();
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        toPost.write(out, "TURTLE");
-        Response postResponse = buildBaseRequestSpecification()
-                .contentType("text/this-is-not-turtle")
-                .body(out.toByteArray())
-            .when()
-                .post(getResourceUri());
- 
-        if (postResponse.getStatusCode() == HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE) {
-            // If we get an unsupported media type status, we're done.
-            return;
-        }
-        
-        // Otherwise, we still might be OK if the server supports non-RDF source,
-        // in which case it might have treated the POST content as binary. Check
-        // the response Content-Type if we ask for the new resource.
-        assertEquals(postResponse.getStatusCode(), HttpStatus.SC_CREATED,
-                "Expected either 415 Unsupported Media Type or 201 Created in response to POST");
-
-        String location = postResponse.getHeader(LOCATION);
-        assertNotNull(location, "No Location response header on 201 Created response");
-
-        Response getResponse = buildBaseRequestSpecification()
-            .expect()
-                .statusCode(isSuccessful())
-                .contentType(not(TEXT_TURTLE))
-            .when()
-                .get(location);
- 
-        // Also make sure there is no Link header indicating this is an RDF source.
-        assertFalse(containsLinkHeader(LDP.RDFSource.stringValue(), LINK_REL_TYPE, getResponse),
-                "Server should not responsd with RDF source Link header when content was created with non-RDF Content-Type");
- 
-        // Clean up.
-        buildBaseRequestSpecification().delete(location);
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "In RDF representations, LDP servers MUST interpret the null relative "
-                    + "URI for the subject of triples in the LDPR representation in the request "
-                    + "entity body as referring to the entity in the request body. Commonly, that "
-                    + "entity is the model for the “to be created” LDPR, so triples whose subject "
-                    + "is the null relative URI will usually result in triples in the created "
-                    + "resource whose subject is the created resource.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-rdfnullrel",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testNullRelativeUri() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Model requestModel = ModelFactory.createDefaultModel();
-        Resource resource = requestModel.createResource("");
-        String identifier = UUID.randomUUID().toString();
-        resource.addProperty(DCTerms.identifier, identifier);
-
-        // Do not pass a URI to RdfObjectMapper so that it stays as the null
-        // relative URI in the request body
-        Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
-                .body(requestModel, new RdfObjectMapper()) // do not pass a URI
-                .expect().statusCode(HttpStatus.SC_CREATED).when()
-                .post(getResourceUri());
-
-        String location = postResponse.getHeader(LOCATION);
-        assertNotNull(location, MSG_LOC_NOTFOUND);
-
-        // Get the resource to check that the resource with a null relative URI
-        // was assigned the URI in the Location response header.
-        Model responseModel = getAsModel(location);
-        Resource created = responseModel.getResource(location);
-
-        // TODO: Is this the best test? It's possible a server will assign its
-        // own dcterms:identifier.
-        assertTrue(
-                created.hasProperty(DCTerms.identifier, identifier),
-                "The resource created with URI <"
-                        + location
-                        + "> does not have the dcterms:identifier as the resource POSTed using the null relative URI."
-        );
-
-        // Delete the resource to clean up.
-        buildBaseRequestSpecification().delete(location);
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers SHOULD assign the URI for the resource to be created "
-                    + "using server application specific rules in the absence of a client hint.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-serverassignuri",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testPostNoSlug() {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        // POST content with no Slug and see if the server assigns a URI.
-        Model model = postContent();
-        Response postResponse = buildBaseRequestSpecification()
-                .contentType(TEXT_TURTLE)
-                .body(model, new RdfObjectMapper())
-             .expect()
-                .statusCode(HttpStatus.SC_CREATED)
-                .header(LOCATION, HeaderMatchers.headerPresent())
-            .when()
-                .post(getResourceUri());
-
-        // Delete the resource to clean up.
-        buildBaseRequestSpecification().delete(postResponse.getHeader(LOCATION));
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers SHOULD allow clients to create new resources without "
-                    + "requiring detailed knowledge of application-specific constraints. This "
-                    + "is a consequence of the requirement to enable simple creation and "
-                    + "modification of LDPRs. LDP servers expose these application-specific "
-                    + "constraints as described in section 4.2.1 General.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-mincontraints",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testCreateWithoutConstraints() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        // Create a resource with one statement (dcterms:identifier).
-        Model requestModel = ModelFactory.createDefaultModel();
-        Resource resource = requestModel.createResource("");
-        String identifier = UUID.randomUUID().toString();
-        resource.addProperty(DCTerms.identifier, identifier);
-
-        Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
-                .body(requestModel, new RdfObjectMapper()).expect()
-                .statusCode(HttpStatus.SC_CREATED).when()
-                .post(getResourceUri());
-
-        // Delete the resource to clean up.
-        String location = postResponse.getHeader(LOCATION);
-        if (location != null) {
-            buildBaseRequestSpecification().delete(location);
-        }
-
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers that allow member creation via POST SHOULD NOT re-use URIs.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-dontreuseuris",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testRestrictUriReUseSlug() throws URISyntaxException {
-        testRestrictUriReUse("uritest");
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers that allow member creation via POST SHOULD NOT re-use URIs.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-dontreuseuris",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testRestrictUriReUseNoSlug() throws URISyntaxException {
-        testRestrictUriReUse(null);
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "LDP servers that support POST MUST include an Accept-Post "
-                    + "response header on HTTP OPTIONS responses, listing post document "
-                    + "media type(s) supported by the server.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-acceptposthdr",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testAcceptPostResponseHeader() {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Response optionsResponse = buildBaseRequestSpecification().expect()
-                .statusCode(isSuccessful()).when()
-                .options(getResourceUri());
-        assertNotNull(
-                optionsResponse.getHeader(ACCEPT_POST),
-                "The HTTP OPTIONS response on container <"
-                        + getResourceUri()
-                        + "> did not include an Accept-Post response header, but it lists POST in its Allow response header."
-        );
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers SHOULD NOT allow HTTP PUT to update an LDPC’s "
-                    + "containment triples; if the server receives such a request, it "
-                    + "SHOULD respond with a 409 (Conflict) status code.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-put-mbrprops",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testRejectPutModifyingContainmentTriples() {
-        String containerUri = getResourceUri();
-        Response response = buildBaseRequestSpecification()
-                .header(ACCEPT, TEXT_TURTLE)
-                .expect().statusCode(isSuccessful())
-                .when().get(containerUri);
-        String eTag = response.getHeader(ETAG);
-        Model model = response.as(Model.class, new RdfObjectMapper(containerUri));
-
-        // Try to modify the ldp:contains triple.
-        Resource containerResource = model.getResource(containerUri);
-        containerResource.addProperty(model.createProperty(LDP.contains.stringValue()),
-                model.createResource("#" + System.currentTimeMillis()));
-
-        RequestSpecification putRequest = buildBaseRequestSpecification().contentType(TEXT_TURTLE);
-        if (eTag != null) {
-            putRequest.header(IF_MATCH, eTag);
-        }
-        putRequest.body(model, new RdfObjectMapper(containerUri))
-                .expect().statusCode(not(isSuccessful()))
-                .when().put(containerUri);
-    }
-
-    @Test(
-            groups = {SHOULD},
-            dependsOnMethods = {"testPutToCreate"},
-            description = "LDP servers that allow LDPR creation via PUT SHOULD NOT "
-                    + "re-use URIs. For RDF representations (LDP-RSs),the created "
-                    + "resource can be thought of as an RDF named graph [rdf11-concepts].")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-put-create",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testRestrictPutReUseUri() {
-        String location = putToCreate();
-
-        // Delete the resource.
-        buildBaseRequestSpecification()
-                .expect()
-                .statusCode(isSuccessful())
-                .when()
-                .delete(location);
-
-        // Try to put to the same URI again. It should fail.
-        Model content = postContent();
-        buildBaseRequestSpecification()
-                .given()
-                .contentType(TEXT_TURTLE)
-                .body(content, new RdfObjectMapper(location))
-                .expect()
-                .statusCode(not(isSuccessful()))
-                .when()
-                .put(location);
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "When an LDPR identified by the object of a containment triple "
-                    + "is deleted, the LDPC server MUST also remove the LDPR from the "
-                    + "containing LDPC by removing the corresponding containment triple.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-del-contremovesconttriple",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testDeleteRemovesContainmentTriple() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        Model model = postContent();
-        Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
-                .body(model, new RdfObjectMapper()).expect()
-                .statusCode(HttpStatus.SC_CREATED).when()
-                .post(getResourceUri());
-
-        // POST support is optional. Only test delete if the POST succeeded.
-        if (postResponse.getStatusCode() != HttpStatus.SC_CREATED) {
-            throw new SkipException("HTTP POST failed with status "
-                    + postResponse.getStatusCode());
-        }
-
-        String location = postResponse.getHeader(LOCATION);
-        assertNotNull(location, MSG_LOC_NOTFOUND);
-
-        // TODO: Check if delete is supported on location.....
-
-        // Delete the resource
-        buildBaseRequestSpecification().expect().statusCode(isSuccessful()).when()
-                .delete(location);
-
-        // Test the membership triple
-        Model containerModel = getAsModel(getResourceUri());
-        Resource container = containerModel.getResource(getResourceUri());
-
-        assertFalse(
-                container.hasProperty(containerModel
-                                .createProperty(LDP.contains.stringValue()),
-                        containerModel.getResource(location)
-                ),
-                "The LDPC server must remove the corresponding containment triple when an LDPR is deleted."
-        );
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers are RECOMMENDED to support HTTP PATCH as the "
-                    + "preferred method for updating an LDPC's empty-container triples. ")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-patch-req",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPatchMethod() {
-        assertTrue(
-                supports(HttpMethod.PATCH),
-                "Container <"
-                        + getResourceUri()
-                        + "> has not advertised PATCH support through its HTTP OPTIONS response."
-        );
-
-        // TODO: Actually try to patch the containment triples.
-    }
-
-    @Test(
-            groups = {MAY},
-            description = "The representation of a LDPC MAY have an rdf:type "
-                    + "of ldp:Container for Linked Data Platform Container. Non-normative "
-                    + "note: LDPCs might have additional types, like any LDP-RS. ")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-typecontainer",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testRdfTypeLdpContainer() {
-        String container = getResourceUri();
-        Model m = buildBaseRequestSpecification()
-                .header(ACCEPT, TEXT_TURTLE)
-            .expect()
-                .statusCode(isSuccessful())
-            .when()
-                .get(container).as(Model.class, new RdfObjectMapper(container));
-        assertTrue(m.contains(m.getResource(container), RDF.type, m.getResource(LDP.Container.stringValue())),
-                "LDPC does not have an rdf:type of ldp:Container");
-    }
-
-    @Test(
-            enabled = false,
-            groups = {MAY},
-            description = "LDP servers MAY allow clients to suggest "
-                    + "the URI for a resource created through POST, "
-                    + "using the HTTP Slug header as defined in [RFC5023]. "
-                    + "LDP adds no new requirements to this usage, so its "
-                    + "presence functions as a client hint to the server "
-                    + "providing a desired string to be incorporated into the "
-                    + "server's final choice of resource URI.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-slug",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testServerHonorsSlug() {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-
-        // Come up with a unique slug header.
-        String slug = UUID.randomUUID().toString();
-
-        // POST two resources with the same Slug header and content to make sure
-        // they have different URIs.
-        Model content = postContent();
-        String location = post(content, slug);
-        
-        assertTrue(location.contains(slug), "Slug is not part of the return Location");
-        
-        // Clean up.
-        buildBaseRequestSpecification().delete(location);
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers SHOULD accept a request entity "
-                    + "body with a request header of Content-Type with "
-                    + "value of application/ld+json [JSON-LD].")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-jsonld",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testPostJsonLd() {
-        skipIfMethodNotAllowed(HttpMethod.POST);
-        
-        // POST content as JSON-LD.
-        Model model = postContent();
-        Response postResponse = buildBaseRequestSpecification()
-                .contentType(APPLICATION_LD_JSON)
-                .body(model, new RdfObjectMapper())
-            .expect()
-                .statusCode(HttpStatus.SC_CREATED)
-                .header(LOCATION, HeaderMatchers.headerPresent())
-            .when()
-                .post(getResourceUri());
-        
-        // Get the resource back to make sure it wasn't simply treated as a
-        // binary resource. We should be able to get it as text/turtle.
-        Response getResponse = buildBaseRequestSpecification()
-            .expect()
-                .statusCode(isSuccessful())
-                .contentType(TEXT_TURTLE)   // if no Accept header, LDP servers must return text/turtle for RDF source
-            .when()
-                .get(postResponse.getHeader(LOCATION));
-        assertFalse(containsLinkHeader(LDP.NonRDFSource.stringValue(), LINK_REL_TYPE, getResponse),
-                "Resources POSTed using JSON-LD should be treated as RDF source");
-    }
-
+	public static final String MSG_LOC_NOTFOUND = "Location header missing after POST create.";
+	public static final String MSG_MBRRES_NOTFOUND = "Unable to locate object in triple with predicate ldp:membershipResource.";
+	public static final String MSG_PREFERENCE_NOT_APPLIED = "Server did not return Preference-Applied: return=representation response header";
+
+	@Parameters("auth")
+	public CommonContainerTest(@Optional String auth) throws IOException {
+		super(auth);
+	}
+
+	@Test(
+			groups = {MAY},
+			description = "LDP servers MAY choose to allow the creation of new "
+					+ "resources using HTTP PUT.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-create",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPutToCreate() {
+		String location = putToCreate();
+		buildBaseRequestSpecification().delete(location);
+	}
+
+	@Test(
+			enabled = false,
+			groups = {MUST},
+			description = "LDP servers MUST assign the default base-URI "
+					+ "for [RFC3987] relative-URI resolution to be the HTTP "
+					+ "Request-URI when the resource already exists, and to "
+					+ "the URI of the created resource when the request results "
+					+ "in the creation of a new resource.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-defbaseuri",
+			testMethod = METHOD.NOT_IMPLEMENTED,
+			approval = STATUS.WG_PENDING)
+	public void testRelativeUriResolutionPost() {
+		// TODO: Impl testRelativeUriResolutionPost
+	}
+
+	@Test(
+			groups = {SHOULD},
+			description = "LDPC representations SHOULD NOT use RDF container "
+					+ "types rdf:Bag, rdf:Seq or rdf:List.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-nordfcontainertypes",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testNoRdfBagSeqOrList() {
+		Model containerModel = getAsModel(getResourceUri());
+		assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.Bag)
+				.hasNext(), "LDPC representations should not use rdf:Bag");
+		assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.Seq)
+				.hasNext(), "LDPC representations should not use rdf:Seq");
+		assertFalse(containerModel.listResourcesWithProperty(RDF.type, RDF.List).hasNext(),
+				"LDPC representations should not use rdf:List"
+		);
+	}
+
+	@Test(
+			groups = {SHOULD},
+			description = "LDP servers SHOULD respect all of a client's LDP-defined "
+					+ "hints, for example which subsets of LDP-defined state the "
+					+ "client is interested in processing, to influence the set of "
+					+ "triples returned in representations of an LDPC, particularly for "
+					+ "large LDPCs. See also [LDP-PAGING].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-prefer",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testPreferContainmentTriples() {
+		Response response;
+		Model model;
+		String containerUri = getResourceUri();
+
+		// Ask for containment triples.
+		response = buildBaseRequestSpecification()
+					.header(ACCEPT, TEXT_TURTLE)
+					.header(PREFER, include(PREFER_CONTAINMENT)) // request all containment triples
+				.expect()
+					.statusCode(isSuccessful())
+				.when()
+					.get(containerUri);
+		model = response.as(Model.class, new RdfObjectMapper(containerUri));
+
+		assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
+
+		// Assumes the container is not empty.
+		assertTrue(model.contains(model.getResource(containerUri), model.createProperty(LDP.contains.stringValue())),
+				"Container does not have containment triples");
+
+		// Ask for a minimal container.
+		response = buildBaseRequestSpecification()
+					.header(ACCEPT, TEXT_TURTLE)
+					.header(PREFER, include(PREFER_MINIMAL_CONTAINER)) // request no containment triples
+				.expect()
+					.statusCode(isSuccessful())
+				.when()
+					.get(containerUri);
+		model = response.as(Model.class, new RdfObjectMapper(containerUri));
+
+		assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
+		assertFalse(model.contains(model.getResource(containerUri), model.createProperty(LDP.contains.stringValue())),
+				"Container has containment triples when minimal container was requested");
+
+		// Ask to omit containment triples.
+		response = buildBaseRequestSpecification()
+					.header(ACCEPT, TEXT_TURTLE)
+					.header(PREFER, omit(PREFER_CONTAINMENT)) // request no containment triples
+				.expect()
+					.statusCode(isSuccessful())
+				.when()
+					.get(containerUri);
+		model = response.as(Model.class, new RdfObjectMapper(containerUri));
+
+		assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
+
+		// Assumes the container is not empty.
+		assertFalse(model.contains(model.getResource(containerUri), model.createProperty(LDP.contains.stringValue())),
+				"Container has containment triples when client requested server omit them");
+	}
+
+	@Test(
+			groups = {SHOULD},
+			description = "LDPC clients SHOULD create member resources by "
+					+ "submitting a representation as the entity body of the "
+					+ "HTTP POST to a known LDPC.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-created201",
+			testMethod = METHOD.CLIENT_ONLY,
+			approval = STATUS.WG_APPROVED)
+	public void testClientPostToCreate() {
+		throw new SkipClientTestException();
+	}
+
+	@Test(
+			groups = {MUST},
+			description = "If the resource was created successfully, LDP servers MUST "
+					+ "respond with status code 201 (Created) and the Location "
+					+ "header set to the new resource’s URL. Clients shall not "
+					+ "expect any representation in the response entity body on "
+					+ "a 201 (Created) response.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-created201",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPostResponseStatusAndLocation() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Model model = postContent();
+		Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(getResourceUri());
+
+		String location = postResponse.getHeader(LOCATION);
+		assertNotNull(location, MSG_LOC_NOTFOUND);
+
+		buildBaseRequestSpecification().delete(location);
+	}
+
+	@Test(
+			groups = {MUST},
+			description = "When a successful HTTP POST request to an LDPC results "
+					+ "in the creation of an LDPR, a containment triple MUST be "
+					+ "added to the state of LDPC.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createdmbr-contains",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPostContainer() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Model model = postContent();
+		String containerUri = getResourceUri();
+		Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(getResourceUri());
+
+		String location = postResponse.getHeader(LOCATION);
+		assertNotNull(location, MSG_LOC_NOTFOUND);
+
+		Model containerModel = getAsModel(containerUri);
+		Resource container = containerModel.getResource(containerUri);
+
+		assertTrue(
+				container.hasProperty(containerModel
+								.createProperty(LDP.contains.stringValue()),
+						containerModel.getResource(location)
+				),
+				"Container <"
+						+ containerUri
+						+ "> does not have a containment triple for newly created resource <"
+						+ location + ">."
+		);
+
+		buildBaseRequestSpecification().delete(location);
+	}
+
+	@Test(
+			groups = {MUST},
+			description = "LDP servers that successfully create a resource from a "
+					+ "RDF representation in the request entity body MUST honor the "
+					+ "client's requested interaction model(s). The created resource "
+					+ "can be thought of as an RDF named graph [rdf11-concepts]. If any "
+					+ "model cannot be honored, the server MUST fail the request.")
+	@Parameters("containerAsResource")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createrdf",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testRequestedInteractionModelCreateNotAllowed(@Optional String containerAsResource) {
+		if (containerAsResource == null)
+			throw new SkipException("containerAsResource is null");
+
+		Model model = postContent();
+
+		// If create is successful, then not acting like a plain ole resource
+		Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper())
+				.post(containerAsResource);
+
+		// Cleanup if it actually created something
+		String location = postResponse.getHeader(LOCATION);
+		if (postResponse.statusCode() == HttpStatus.SC_CREATED && location !=null)
+			buildBaseRequestSpecification().delete(location);
+
+		assertNotEquals(postResponse.statusCode(), HttpStatus.SC_CREATED, "Resources with interaction model of only ldp:Resources shouldn't allow container POST-create behavior.");
+
+		// TODO: Possibly parse 'Allow' header to see if POST is wrongly listed
+	}
+
+	@Test(
+			groups = {MUST},
+			description = "LDP servers that successfully create a resource from a "
+					+ "RDF representation in the request entity body MUST honor the "
+					+ "client's requested interaction model(s). The created resource "
+					+ "can be thought of as an RDF named graph [rdf11-concepts]. If any "
+					+ "model cannot be honored, the server MUST fail the request.")
+	@Parameters("containerAsResource")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createrdf",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testRequestedInteractionModelHeaders(@Optional String containerAsResource) {
+		if (containerAsResource == null)
+			throw new SkipException("containerAsResource is null");
+
+		// Ensure we don't get back any of the container types in the rel='type' Link header
+		Response response = buildBaseRequestSpecification().expect().statusCode(HttpStatus.SC_OK)
+				.options(containerAsResource);
+		assertFalse(
+				containsLinkHeader(LDP.BasicContainer.stringValue(), LINK_REL_TYPE, response) ||
+				containsLinkHeader(LDP.DirectContainer.stringValue(), LINK_REL_TYPE, response) ||
+				containsLinkHeader(LDP.IndirectContainer.stringValue(), LINK_REL_TYPE, response),
+				"Resource wrongly advertising itself as a rel='type' of one of the container types."
+		);
+
+	}
+
+	@Test(
+			groups = {MUST},
+			description = "LDP servers MUST accept a request entity body with a "
+					+ "request header of Content-Type with value of text/turtle [turtle].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-turtle",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testAcceptTurtle() {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Model model = postContent();
+		Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(getResourceUri());
+
+		// Delete the resource to clean up.
+		String location = postResponse.getHeader(LOCATION);
+		if (location != null) {
+			buildBaseRequestSpecification().delete(location);
+		}
+	}
+
+	@Test(
+			groups = {SHOULD},
+			description = "LDP servers SHOULD use the Content-Type request header to "
+					+ "determine the representation format when the request has an "
+					+ "entity body.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-contenttype",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testContentTypeHeader() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		// POST Turtle content with a bad Content-Type request header to see what happens.
+		Model toPost = postContent();
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		toPost.write(out, "TURTLE");
+		Response postResponse = buildBaseRequestSpecification()
+				.contentType("text/this-is-not-turtle")
+				.body(out.toByteArray())
+			.when()
+				.post(getResourceUri());
+
+		if (postResponse.getStatusCode() == HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE) {
+			// If we get an unsupported media type status, we're done.
+			return;
+		}
+
+		// Otherwise, we still might be OK if the server supports non-RDF source,
+		// in which case it might have treated the POST content as binary. Check
+		// the response Content-Type if we ask for the new resource.
+		assertEquals(postResponse.getStatusCode(), HttpStatus.SC_CREATED,
+				"Expected either 415 Unsupported Media Type or 201 Created in response to POST");
+
+		String location = postResponse.getHeader(LOCATION);
+		assertNotNull(location, "No Location response header on 201 Created response");
+
+		Response getResponse = buildBaseRequestSpecification()
+			.expect()
+				.statusCode(isSuccessful())
+				.contentType(not(TEXT_TURTLE))
+			.when()
+				.get(location);
+
+		// Also make sure there is no Link header indicating this is an RDF source.
+		assertFalse(containsLinkHeader(LDP.RDFSource.stringValue(), LINK_REL_TYPE, getResponse),
+				"Server should not responsd with RDF source Link header when content was created with non-RDF Content-Type");
+
+		// Clean up.
+		buildBaseRequestSpecification().delete(location);
+	}
+
+	@Test(
+			groups = {MUST},
+			description = "In RDF representations, LDP servers MUST interpret the null relative "
+					+ "URI for the subject of triples in the LDPR representation in the request "
+					+ "entity body as referring to the entity in the request body. Commonly, that "
+					+ "entity is the model for the “to be created” LDPR, so triples whose subject "
+					+ "is the null relative URI will usually result in triples in the created "
+					+ "resource whose subject is the created resource.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-rdfnullrel",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testNullRelativeUri() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Model requestModel = ModelFactory.createDefaultModel();
+		Resource resource = requestModel.createResource("");
+		String identifier = UUID.randomUUID().toString();
+		resource.addProperty(DCTerms.identifier, identifier);
+
+		// Do not pass a URI to RdfObjectMapper so that it stays as the null
+		// relative URI in the request body
+		Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
+				.body(requestModel, new RdfObjectMapper()) // do not pass a URI
+				.expect().statusCode(HttpStatus.SC_CREATED).when()
+				.post(getResourceUri());
+
+		String location = postResponse.getHeader(LOCATION);
+		assertNotNull(location, MSG_LOC_NOTFOUND);
+
+		// Get the resource to check that the resource with a null relative URI
+		// was assigned the URI in the Location response header.
+		Model responseModel = getAsModel(location);
+		Resource created = responseModel.getResource(location);
+
+		// TODO: Is this the best test? It's possible a server will assign its
+		// own dcterms:identifier.
+		assertTrue(
+				created.hasProperty(DCTerms.identifier, identifier),
+				"The resource created with URI <"
+						+ location
+						+ "> does not have the dcterms:identifier as the resource POSTed using the null relative URI."
+		);
+
+		// Delete the resource to clean up.
+		buildBaseRequestSpecification().delete(location);
+	}
+
+	@Test(
+			groups = {SHOULD},
+			description = "LDP servers SHOULD assign the URI for the resource to be created "
+					+ "using server application specific rules in the absence of a client hint.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-serverassignuri",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testPostNoSlug() {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		// POST content with no Slug and see if the server assigns a URI.
+		Model model = postContent();
+		Response postResponse = buildBaseRequestSpecification()
+				.contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper())
+			 .expect()
+				.statusCode(HttpStatus.SC_CREATED)
+				.header(LOCATION, HeaderMatchers.headerPresent())
+			.when()
+				.post(getResourceUri());
+
+		// Delete the resource to clean up.
+		buildBaseRequestSpecification().delete(postResponse.getHeader(LOCATION));
+	}
+
+	@Test(
+			groups = {SHOULD},
+			description = "LDP servers SHOULD allow clients to create new resources without "
+					+ "requiring detailed knowledge of application-specific constraints. This "
+					+ "is a consequence of the requirement to enable simple creation and "
+					+ "modification of LDPRs. LDP servers expose these application-specific "
+					+ "constraints as described in section 4.2.1 General.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-mincontraints",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testCreateWithoutConstraints() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		// Create a resource with one statement (dcterms:identifier).
+		Model requestModel = ModelFactory.createDefaultModel();
+		Resource resource = requestModel.createResource("");
+		String identifier = UUID.randomUUID().toString();
+		resource.addProperty(DCTerms.identifier, identifier);
+
+		Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
+				.body(requestModel, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(getResourceUri());
+
+		// Delete the resource to clean up.
+		String location = postResponse.getHeader(LOCATION);
+		if (location != null) {
+			buildBaseRequestSpecification().delete(location);
+		}
+
+	}
+
+	@Test(
+			groups = {SHOULD},
+			description = "LDP servers that allow member creation via POST SHOULD NOT re-use URIs.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-dontreuseuris",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testRestrictUriReUseSlug() throws URISyntaxException {
+		testRestrictUriReUse("uritest");
+	}
+
+	@Test(
+			groups = {SHOULD},
+			description = "LDP servers that allow member creation via POST SHOULD NOT re-use URIs.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-dontreuseuris",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testRestrictUriReUseNoSlug() throws URISyntaxException {
+		testRestrictUriReUse(null);
+	}
+
+	@Test(
+			groups = {MUST},
+			description = "LDP servers that support POST MUST include an Accept-Post "
+					+ "response header on HTTP OPTIONS responses, listing post document "
+					+ "media type(s) supported by the server.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-acceptposthdr",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testAcceptPostResponseHeader() {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Response optionsResponse = buildBaseRequestSpecification().expect()
+				.statusCode(isSuccessful()).when()
+				.options(getResourceUri());
+		assertNotNull(
+				optionsResponse.getHeader(ACCEPT_POST),
+				"The HTTP OPTIONS response on container <"
+						+ getResourceUri()
+						+ "> did not include an Accept-Post response header, but it lists POST in its Allow response header."
+		);
+	}
+
+	@Test(
+			groups = {SHOULD},
+			description = "LDP servers SHOULD NOT allow HTTP PUT to update an LDPC’s "
+					+ "containment triples; if the server receives such a request, it "
+					+ "SHOULD respond with a 409 (Conflict) status code.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-put-mbrprops",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testRejectPutModifyingContainmentTriples() {
+		String containerUri = getResourceUri();
+		Response response = buildBaseRequestSpecification()
+				.header(ACCEPT, TEXT_TURTLE)
+				.expect().statusCode(isSuccessful())
+				.when().get(containerUri);
+		String eTag = response.getHeader(ETAG);
+		Model model = response.as(Model.class, new RdfObjectMapper(containerUri));
+
+		// Try to modify the ldp:contains triple.
+		Resource containerResource = model.getResource(containerUri);
+		containerResource.addProperty(model.createProperty(LDP.contains.stringValue()),
+				model.createResource("#" + System.currentTimeMillis()));
+
+		RequestSpecification putRequest = buildBaseRequestSpecification().contentType(TEXT_TURTLE);
+		if (eTag != null) {
+			putRequest.header(IF_MATCH, eTag);
+		}
+		putRequest.body(model, new RdfObjectMapper(containerUri))
+				.expect().statusCode(not(isSuccessful()))
+				.when().put(containerUri);
+	}
+
+	@Test(
+			groups = {SHOULD},
+			dependsOnMethods = {"testPutToCreate"},
+			description = "LDP servers that allow LDPR creation via PUT SHOULD NOT "
+					+ "re-use URIs. For RDF representations (LDP-RSs),the created "
+					+ "resource can be thought of as an RDF named graph [rdf11-concepts].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-put-create",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testRestrictPutReUseUri() {
+		String location = putToCreate();
+
+		// Delete the resource.
+		buildBaseRequestSpecification()
+				.expect()
+				.statusCode(isSuccessful())
+				.when()
+				.delete(location);
+
+		// Try to put to the same URI again. It should fail.
+		Model content = postContent();
+		buildBaseRequestSpecification()
+				.given()
+				.contentType(TEXT_TURTLE)
+				.body(content, new RdfObjectMapper(location))
+				.expect()
+				.statusCode(not(isSuccessful()))
+				.when()
+				.put(location);
+	}
+
+	@Test(
+			groups = {MUST},
+			description = "When an LDPR identified by the object of a containment triple "
+					+ "is deleted, the LDPC server MUST also remove the LDPR from the "
+					+ "containing LDPC by removing the corresponding containment triple.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-del-contremovesconttriple",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testDeleteRemovesContainmentTriple() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		Model model = postContent();
+		Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(getResourceUri());
+
+		// POST support is optional. Only test delete if the POST succeeded.
+		if (postResponse.getStatusCode() != HttpStatus.SC_CREATED) {
+			throw new SkipException("HTTP POST failed with status "
+					+ postResponse.getStatusCode());
+		}
+
+		String location = postResponse.getHeader(LOCATION);
+		assertNotNull(location, MSG_LOC_NOTFOUND);
+
+		// TODO: Check if delete is supported on location.....
+
+		// Delete the resource
+		buildBaseRequestSpecification().expect().statusCode(isSuccessful()).when()
+				.delete(location);
+
+		// Test the membership triple
+		Model containerModel = getAsModel(getResourceUri());
+		Resource container = containerModel.getResource(getResourceUri());
+
+		assertFalse(
+				container.hasProperty(containerModel
+								.createProperty(LDP.contains.stringValue()),
+						containerModel.getResource(location)
+				),
+				"The LDPC server must remove the corresponding containment triple when an LDPR is deleted."
+		);
+	}
+
+	@Test(
+			groups = {SHOULD},
+			description = "LDP servers are RECOMMENDED to support HTTP PATCH as the "
+					+ "preferred method for updating an LDPC's empty-container triples. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-patch-req",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPatchMethod() {
+		assertTrue(
+				supports(HttpMethod.PATCH),
+				"Container <"
+						+ getResourceUri()
+						+ "> has not advertised PATCH support through its HTTP OPTIONS response."
+		);
+
+		// TODO: Actually try to patch the containment triples.
+	}
+
+	@Test(
+			groups = {MAY},
+			description = "The representation of a LDPC MAY have an rdf:type "
+					+ "of ldp:Container for Linked Data Platform Container. Non-normative "
+					+ "note: LDPCs might have additional types, like any LDP-RS. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-typecontainer",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testRdfTypeLdpContainer() {
+		String container = getResourceUri();
+		Model m = buildBaseRequestSpecification()
+				.header(ACCEPT, TEXT_TURTLE)
+			.expect()
+				.statusCode(isSuccessful())
+			.when()
+				.get(container).as(Model.class, new RdfObjectMapper(container));
+		assertTrue(m.contains(m.getResource(container), RDF.type, m.getResource(LDP.Container.stringValue())),
+				"LDPC does not have an rdf:type of ldp:Container");
+	}
+
+	@Test(
+			enabled = false,
+			groups = {MAY},
+			description = "LDP servers MAY allow clients to suggest "
+					+ "the URI for a resource created through POST, "
+					+ "using the HTTP Slug header as defined in [RFC5023]. "
+					+ "LDP adds no new requirements to this usage, so its "
+					+ "presence functions as a client hint to the server "
+					+ "providing a desired string to be incorporated into the "
+					+ "server's final choice of resource URI.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-slug",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testServerHonorsSlug() {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		// Come up with a unique slug header.
+		String slug = UUID.randomUUID().toString();
+
+		// POST two resources with the same Slug header and content to make sure
+		// they have different URIs.
+		Model content = postContent();
+		String location = post(content, slug);
+
+		assertTrue(location.contains(slug), "Slug is not part of the return Location");
+
+		// Clean up.
+		buildBaseRequestSpecification().delete(location);
+	}
+
+	@Test(
+			groups = {SHOULD},
+			description = "LDP servers SHOULD accept a request entity "
+					+ "body with a request header of Content-Type with "
+					+ "value of application/ld+json [JSON-LD].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-jsonld",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testPostJsonLd() {
+		skipIfMethodNotAllowed(HttpMethod.POST);
+
+		// POST content as JSON-LD.
+		Model model = postContent();
+		Response postResponse = buildBaseRequestSpecification()
+				.contentType(APPLICATION_LD_JSON)
+				.body(model, new RdfObjectMapper())
+			.expect()
+				.statusCode(HttpStatus.SC_CREATED)
+				.header(LOCATION, HeaderMatchers.headerPresent())
+			.when()
+				.post(getResourceUri());
+
+		// Get the resource back to make sure it wasn't simply treated as a
+		// binary resource. We should be able to get it as text/turtle.
+		Response getResponse = buildBaseRequestSpecification()
+			.expect()
+				.statusCode(isSuccessful())
+				.contentType(TEXT_TURTLE)	// if no Accept header, LDP servers must return text/turtle for RDF source
+			.when()
+				.get(postResponse.getHeader(LOCATION));
+		assertFalse(containsLinkHeader(LDP.NonRDFSource.stringValue(), LINK_REL_TYPE, getResponse),
+				"Resources POSTed using JSON-LD should be treated as RDF source");
+	}
+
+	@Override
     protected boolean restrictionsOnContent() {
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Tests that LDP servers do not reuse URIs after deleting resources.
-     *
-     * @param slug the slug header for the request or null if no slug
-     * @throws URISyntaxException on bad URIs
-     * @see #testRestrictUriReUseSlug()
-     * @see #testRestrictUriReUseNoSlug()
-     */
-    private void testRestrictUriReUse(String slug) throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.POST);
+	/**
+	 * Tests that LDP servers do not reuse URIs after deleting resources.
+	 *
+	 * @param slug the slug header for the request or null if no slug
+	 * @throws URISyntaxException on bad URIs
+	 * @see #testRestrictUriReUseSlug()
+	 * @see #testRestrictUriReUseNoSlug()
+	 */
+	private void testRestrictUriReUse(String slug) throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.POST);
 
-        // POST two resources with the same Slug header and content to make sure
-        // they have different URIs.
-        Model content = postContent();
-        String loc1 = post(content, slug);
+		// POST two resources with the same Slug header and content to make sure
+		// they have different URIs.
+		Model content = postContent();
+		String loc1 = post(content, slug);
 
-        // TODO: Test if DELETE is supported before trying to delete the
-        // resource.
-        // Delete the resource to make sure the server doesn't reuse the URI
-        // below.
-        buildBaseRequestSpecification().expect().statusCode(isSuccessful()).when().delete(loc1);
+		// TODO: Test if DELETE is supported before trying to delete the
+		// resource.
+		// Delete the resource to make sure the server doesn't reuse the URI
+		// below.
+		buildBaseRequestSpecification().expect().statusCode(isSuccessful()).when().delete(loc1);
 
-        String loc2 = post(content, slug);
-        assertNotEquals(loc1, loc2, "Server reused URIs for POSTed resources.");
+		String loc2 = post(content, slug);
+		assertNotEquals(loc1, loc2, "Server reused URIs for POSTed resources.");
 
-        buildBaseRequestSpecification().delete(loc2);
-    }
+		buildBaseRequestSpecification().delete(loc2);
+	}
 
-    private String post(Model content, String slug) {
-        RequestSpecification spec = buildBaseRequestSpecification().contentType(TEXT_TURTLE);
-        if (slug != null) {
-            spec.header(SLUG, slug);
-        }
-        Response post = spec.body(content, new RdfObjectMapper()).expect()
-                .statusCode(HttpStatus.SC_CREATED).when()
-                .post(getResourceUri());
-        String location = post.getHeader(LOCATION);
-        assertNotNull(location, MSG_LOC_NOTFOUND);
+	private String post(Model content, String slug) {
+		RequestSpecification spec = buildBaseRequestSpecification().contentType(TEXT_TURTLE);
+		if (slug != null) {
+			spec.header(SLUG, slug);
+		}
+		Response post = spec.body(content, new RdfObjectMapper()).expect()
+				.statusCode(HttpStatus.SC_CREATED).when()
+				.post(getResourceUri());
+		String location = post.getHeader(LOCATION);
+		assertNotNull(location, MSG_LOC_NOTFOUND);
 
-        return location;
-    }
+		return location;
+	}
 
-    /**
-     * Attempts to create a new resource using PUT.
-     *
-     * @return the location of the created resource
-     * @see #testPutToCreate()
-     * @see #testRestrictPutReUseUri()
-     */
-    protected String putToCreate() {
-        // Build a unique URI for the PUT request.
-        URI target = UriBuilder.fromUri(getResourceUri())
-                .path(UUID.randomUUID().toString()).build();
-        Model model = postContent();
-        Response response = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
-                .body(model, new RdfObjectMapper("")).expect()
-                .statusCode(HttpStatus.SC_CREATED).when().put(target);
+	/**
+	 * Attempts to create a new resource using PUT.
+	 *
+	 * @return the location of the created resource
+	 * @see #testPutToCreate()
+	 * @see #testRestrictPutReUseUri()
+	 */
+	protected String putToCreate() {
+		// Build a unique URI for the PUT request.
+		URI target = UriBuilder.fromUri(getResourceUri())
+				.path(UUID.randomUUID().toString()).build();
+		Model model = postContent();
+		Response response = buildBaseRequestSpecification().contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper("")).expect()
+				.statusCode(HttpStatus.SC_CREATED).when().put(target);
 
-        String location = response.getHeader(LOCATION);
-        if (location == null) {
-            return target.toString();
-        }
+		String location = response.getHeader(LOCATION);
+		if (location == null) {
+			return target.toString();
+		}
 
-        return location;
-    }
+		return location;
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
@@ -40,465 +40,466 @@ import com.jayway.restassured.specification.ResponseSpecification;
  */
 public abstract class CommonResourceTest extends LdpTest {
 
-    private Set<String> options = new HashSet<String>();
+	private Set<String> options = new HashSet<String>();
 
-    protected Map<String,String> auth;
+	protected Map<String,String> auth;
 
-    protected abstract String getResourceUri();
+	protected abstract String getResourceUri();
 
-    @BeforeClass(alwaysRun = true)
-    public void determineOptions() {
-        String uri = getResourceUri();
-        if (StringUtils.isNotBlank(uri)) {
-            // Use HTTP OPTIONS, which MUST be supported by LDP servers, to determine what methods are supported on this container.
-            Response optionsResponse = RestAssured.options(uri);
-            String allow = optionsResponse.header(ALLOW);
-            if (allow != null) {
-                String[] methods = allow.split("\\s*,\\s*");
-                for (String method : methods) {
-                    options.add(method);
-                }
-            }
-        }
-    }
+	@BeforeClass(alwaysRun = true)
+	public void determineOptions() {
+		String uri = getResourceUri();
+		if (StringUtils.isNotBlank(uri)) {
+			// Use HTTP OPTIONS, which MUST be supported by LDP servers, to determine what methods are supported on this container.
+			Response optionsResponse = RestAssured.options(uri);
+			String allow = optionsResponse.header(ALLOW);
+			if (allow != null) {
+				String[] methods = allow.split("\\s*,\\s*");
+				for (String method : methods) {
+					options.add(method);
+				}
+			}
+		}
+	}
 
-    @Parameters("auth")
-    public CommonResourceTest(@Optional String auth) throws IOException {
-        if (StringUtils.isNotBlank(auth) && auth.contains(":")) {
-            String[] split = auth.split(":");
-            if (split.length == 2 && StringUtils.isNotBlank(split[0]) && StringUtils.isNotBlank(split[1])) {
-                this.auth = ImmutableMap.of("username", split[0], "password", split[1]);
-            }
-        } else {
-            this.auth = null;
-        }
-    }
+	@Parameters("auth")
+	public CommonResourceTest(@Optional String auth) throws IOException {
+		if (StringUtils.isNotBlank(auth) && auth.contains(":")) {
+			String[] split = auth.split(":");
+			if (split.length == 2 && StringUtils.isNotBlank(split[0]) && StringUtils.isNotBlank(split[1])) {
+				this.auth = ImmutableMap.of("username", split[0], "password", split[1]);
+			}
+		} else {
+			this.auth = null;
+		}
+	}
 
+	@Override
     protected RequestSpecification buildBaseRequestSpecification() {
-        if (auth == null) {
-            return RestAssured.given();
-        } else {
-            return RestAssured.given().auth().basic(auth.get("username"), auth.get("password"));
-        }
-    }
+		if (auth == null) {
+			return RestAssured.given();
+		} else {
+			return RestAssured.given().auth().basic(auth.get("username"), auth.get("password"));
+		}
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers MUST at least be"
-                    + " HTTP/1.1 conformant servers [HTTP11].")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-http",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_EXTENSION)
-    public void testIsHttp11Server() {
-        // TODO: Consider a more extensive test for HTTP/1.1
-        buildBaseRequestSpecification().expect().statusLine(containsString("HTTP/1.1")).when().head(getResourceUri());
-    }
+	@Test(
+			groups = {MUST},
+			description = "LDP servers MUST at least be"
+					+ " HTTP/1.1 conformant servers [HTTP11].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-http",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_EXTENSION)
+	public void testIsHttp11Server() {
+		// TODO: Consider a more extensive test for HTTP/1.1
+		buildBaseRequestSpecification().expect().statusLine(containsString("HTTP/1.1")).when().head(getResourceUri());
+	}
 
-    @Test(
-            enabled = false,
-            groups = {MUST},
-            description = "LDP servers MUST at least be"
-                    + " HTTP/1.1 conformant servers [HTTP11].")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-http",
-            testMethod = METHOD.MANUAL,
-            approval = STATUS.WG_APPROVED)
-    public void testIsHttp11Manual() throws URISyntaxException {
-        // TODO: Impl testIsHttp11Manual
-    }
+	@Test(
+			enabled = false,
+			groups = {MUST},
+			description = "LDP servers MUST at least be"
+					+ " HTTP/1.1 conformant servers [HTTP11].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-http",
+			testMethod = METHOD.MANUAL,
+			approval = STATUS.WG_APPROVED)
+	public void testIsHttp11Manual() throws URISyntaxException {
+		// TODO: Impl testIsHttp11Manual
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP server responses MUST use entity tags "
-                    + "(either weak or strong ones) as response "
-                    + "ETag header values.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-etags",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testETagHeadersGet() {
-        // GET requests
-        buildBaseRequestSpecification()
-            .expect()
-                .statusCode(isSuccessful())
-                .header(ETAG, isValidEntityTag())
-            .when()
-                .get(getResourceUri());
-    }
+	@Test(
+			groups = {MUST},
+			description = "LDP server responses MUST use entity tags "
+					+ "(either weak or strong ones) as response "
+					+ "ETag header values.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-etags",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testETagHeadersGet() {
+		// GET requests
+		buildBaseRequestSpecification()
+			.expect()
+				.statusCode(isSuccessful())
+				.header(ETAG, isValidEntityTag())
+			.when()
+				.get(getResourceUri());
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP server responses MUST use entity tags "
-                    + "(either weak or strong ones) as response "
-                    + "ETag header values.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-etags",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testETagHeadersHead() {
-        // GET requests
-        buildBaseRequestSpecification()
-                .expect().statusCode(isSuccessful()).header(ETAG, isValidEntityTag())
-                .when().head(getResourceUri());
-    }
+	@Test(
+			groups = {MUST},
+			description = "LDP server responses MUST use entity tags "
+					+ "(either weak or strong ones) as response "
+					+ "ETag header values.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-etags",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testETagHeadersHead() {
+		// GET requests
+		buildBaseRequestSpecification()
+				.expect().statusCode(isSuccessful()).header(ETAG, isValidEntityTag())
+				.when().head(getResourceUri());
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers exposing LDPRs MUST advertise "
-                    + "their LDP support by exposing a HTTP Link header "
-                    + "with a target URI of http://www.w3.org/ns/ldp#Resource, "
-                    + "and a link relation type of type (that is, rel='type') "
-                    + "in all responses to requests made to the LDPR's "
-                    + "HTTP Request-URI.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-linktypehdr",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testLdpLinkHeader() {
-        Response response = buildBaseRequestSpecification()
-                .expect().statusCode(isSuccessful())
-                .when().get(getResourceUri());
-        assertTrue(
-                containsLinkHeader(LDP.Resource.stringValue(), LINK_REL_TYPE, response),
-                "4.2.1.4 LDP servers exposing LDPRs must advertise their LDP support by exposing a HTTP Link header "
-                        + "with a target URI of http://www.w3.org/ns/ldp#Resource, and a link relation type of type (that is, "
-                        + "rel='type') in all responses to requests made to the LDPR's HTTP Request-URI. Actual: "
-                        + response.getHeader(LINK)
-        );
-    }
+	@Test(
+			groups = {MUST},
+			description = "LDP servers exposing LDPRs MUST advertise "
+					+ "their LDP support by exposing a HTTP Link header "
+					+ "with a target URI of http://www.w3.org/ns/ldp#Resource, "
+					+ "and a link relation type of type (that is, rel='type') "
+					+ "in all responses to requests made to the LDPR's "
+					+ "HTTP Request-URI.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-linktypehdr",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testLdpLinkHeader() {
+		Response response = buildBaseRequestSpecification()
+				.expect().statusCode(isSuccessful())
+				.when().get(getResourceUri());
+		assertTrue(
+				containsLinkHeader(LDP.Resource.stringValue(), LINK_REL_TYPE, response),
+				"4.2.1.4 LDP servers exposing LDPRs must advertise their LDP support by exposing a HTTP Link header "
+						+ "with a target URI of http://www.w3.org/ns/ldp#Resource, and a link relation type of type (that is, "
+						+ "rel='type') in all responses to requests made to the LDPR's HTTP Request-URI. Actual: "
+						+ response.getHeader(LINK)
+		);
+	}
 
 
-    @Test(
-            enabled = false,
-            groups = {MUST},
-            description = "LDP servers MUST publish any constraints on LDP clients’ "
-                    + "ability to create or update LDPRs, by adding a Link header "
-                    + "with rel='describedby' [RFC5988] to all responses to requests "
-                    + "which fail due to violation of those constraints.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-pubclireqs",
-            testMethod = METHOD.NOT_IMPLEMENTED,
-            approval = STATUS.WG_PENDING)
-    public void testPublishConstraints() {
-        // TODO: Impl testPublishConstraints
-    }
+	@Test(
+			enabled = false,
+			groups = {MUST},
+			description = "LDP servers MUST publish any constraints on LDP clients’ "
+					+ "ability to create or update LDPRs, by adding a Link header "
+					+ "with rel='describedby' [RFC5988] to all responses to requests "
+					+ "which fail due to violation of those constraints.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-pubclireqs",
+			testMethod = METHOD.NOT_IMPLEMENTED,
+			approval = STATUS.WG_PENDING)
+	public void testPublishConstraints() {
+		// TODO: Impl testPublishConstraints
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers MUST support the HTTP GET Method for LDPRs")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-get-must",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testGetResource() {
-        assertTrue(supports(HttpMethod.GET), "HTTP GET is not listed in the Allow response header on HTTP OPTIONS requests for resource <" + getResourceUri() + ">");
-        buildBaseRequestSpecification()
-                .expect().statusCode(isSuccessful())
-                .when().get(getResourceUri());
-    }
+	@Test(
+			groups = {MUST},
+			description = "LDP servers MUST support the HTTP GET Method for LDPRs")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-get-must",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testGetResource() {
+		assertTrue(supports(HttpMethod.GET), "HTTP GET is not listed in the Allow response header on HTTP OPTIONS requests for resource <" + getResourceUri() + ">");
+		buildBaseRequestSpecification()
+				.expect().statusCode(isSuccessful())
+				.when().get(getResourceUri());
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers MUST support the HTTP response headers "
-                    + "defined in section 4.2.8 HTTP OPTIONS. ")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-get-options",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testGetResponseHeaders() {
-        ResponseSpecification expectResponse = buildBaseRequestSpecification().expect();
-        expectResponse.header(ALLOW, notNullValue());
+	@Test(
+			groups = {MUST},
+			description = "LDP servers MUST support the HTTP response headers "
+					+ "defined in section 4.2.8 HTTP OPTIONS. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-get-options",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testGetResponseHeaders() {
+		ResponseSpecification expectResponse = buildBaseRequestSpecification().expect();
+		expectResponse.header(ALLOW, notNullValue());
 
-        // Some headers are expected depending on OPTIONS
-        if (supports(HttpMethod.PATCH)) {
-            expectResponse.header(ACCEPT_PATCH, notNullValue());
-        }
+		// Some headers are expected depending on OPTIONS
+		if (supports(HttpMethod.PATCH)) {
+			expectResponse.header(ACCEPT_PATCH, notNullValue());
+		}
 
-        if (supports(HttpMethod.POST)) {
-            expectResponse.header(ACCEPT_POST, notNullValue());
-        }
+		if (supports(HttpMethod.POST)) {
+			expectResponse.header(ACCEPT_POST, notNullValue());
+		}
 
-        expectResponse.when().get(getResourceUri());
-    }
+		expectResponse.when().get(getResourceUri());
+	}
 
-    @Test(
-            enabled = false,
-            groups = {MUST},
-            description = "If an otherwise valid HTTP PUT request is received that "
-                    + "attempts to change properties the server does not allow "
-                    + "clients to modify, LDP servers MUST respond with a 4xx range "
-                    + "status code (typically 409 Conflict)")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-put-servermanagedprops",
-            testMethod = METHOD.NOT_IMPLEMENTED,
-            approval = STATUS.WG_PENDING)
-    public void testPutReadOnlyProperties4xxStatus() {
-        // TODO: Impl testPutReadOnlyProperties4xxStatus
-    }
+	@Test(
+			enabled = false,
+			groups = {MUST},
+			description = "If an otherwise valid HTTP PUT request is received that "
+					+ "attempts to change properties the server does not allow "
+					+ "clients to modify, LDP servers MUST respond with a 4xx range "
+					+ "status code (typically 409 Conflict)")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-put-servermanagedprops",
+			testMethod = METHOD.NOT_IMPLEMENTED,
+			approval = STATUS.WG_PENDING)
+	public void testPutReadOnlyProperties4xxStatus() {
+		// TODO: Impl testPutReadOnlyProperties4xxStatus
+	}
 
-    @Test(
-            enabled = false,
-            groups = {SHOULD},
-            dependsOnMethods = {"testInvalidPutPropertiesNotAllowed"},
-            description = "LDP servers SHOULD provide a corresponding response body containing "
-                    + "information about which properties could not be persisted. The "
-                    + "format of the 4xx response body is not constrained by LDP.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-put-servermanagedprops",
-            testMethod = METHOD.NOT_IMPLEMENTED,
-            approval = STATUS.WG_PENDING)
-    public void test4xxErrorHasResponseBody() {
-        // TODO: Impl test4xxErrorHasResponseBody
-    }
+	@Test(
+			enabled = false,
+			groups = {SHOULD},
+			dependsOnMethods = {"testInvalidPutPropertiesNotAllowed"},
+			description = "LDP servers SHOULD provide a corresponding response body containing "
+					+ "information about which properties could not be persisted. The "
+					+ "format of the 4xx response body is not constrained by LDP.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-put-servermanagedprops",
+			testMethod = METHOD.NOT_IMPLEMENTED,
+			approval = STATUS.WG_PENDING)
+	public void test4xxErrorHasResponseBody() {
+		// TODO: Impl test4xxErrorHasResponseBody
+	}
 
-    @Test(
-            enabled = false,
-            groups = {MUST},
-            description = "If an otherwise valid HTTP PUT request is received that "
-                    + "contains properties the server chooses not to persist, "
-                    + "e.g. unknown content, LDP servers MUST respond with an "
-                    + "appropriate 4xx range status code [HTTP11].")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-put-failed",
-            testMethod = METHOD.NOT_IMPLEMENTED,
-            approval = STATUS.WG_PENDING)
-    public void testPutPropertiesNotPersisted() {
-        // TODO: Impl testPutPropertiesNotPersisted
-    }
+	@Test(
+			enabled = false,
+			groups = {MUST},
+			description = "If an otherwise valid HTTP PUT request is received that "
+					+ "contains properties the server chooses not to persist, "
+					+ "e.g. unknown content, LDP servers MUST respond with an "
+					+ "appropriate 4xx range status code [HTTP11].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-put-failed",
+			testMethod = METHOD.NOT_IMPLEMENTED,
+			approval = STATUS.WG_PENDING)
+	public void testPutPropertiesNotPersisted() {
+		// TODO: Impl testPutPropertiesNotPersisted
+	}
 
-    @Test(
-            enabled = false,
-            groups = {SHOULD},
-            dependsOnMethods = {"testInvalidPutPropertiesNotPersisted"},
-            description = "LDP servers SHOULD provide a corresponding response body containing "
-                    + "information about which properties could not be persisted. The "
-                    + "format of the 4xx response body is not constrained by LDP. LDP "
-                    + "servers expose these application-specific constraints as described "
-                    + "in section 4.2.1 General.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-put-failed",
-            testMethod = METHOD.NOT_IMPLEMENTED,
-            approval = STATUS.WG_PENDING)
-    public void testResponsePropertiesNotPersisted() {
-        // TODO: Impl testResponsePropertiesNotPersisted
-    }
+	@Test(
+			enabled = false,
+			groups = {SHOULD},
+			dependsOnMethods = {"testInvalidPutPropertiesNotPersisted"},
+			description = "LDP servers SHOULD provide a corresponding response body containing "
+					+ "information about which properties could not be persisted. The "
+					+ "format of the 4xx response body is not constrained by LDP. LDP "
+					+ "servers expose these application-specific constraints as described "
+					+ "in section 4.2.1 General.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-put-failed",
+			testMethod = METHOD.NOT_IMPLEMENTED,
+			approval = STATUS.WG_PENDING)
+	public void testResponsePropertiesNotPersisted() {
+		// TODO: Impl testResponsePropertiesNotPersisted
+	}
 
-    @Test(
-            groups = {SHOULD},
-            description = "LDP clients SHOULD use the HTTP If-Match header and HTTP ETags "
-                    + "to ensure it isn’t modifying a resource that has changed since the "
-                    + "client last retrieved its representation. LDP servers SHOULD require "
-                    + "the HTTP If-Match header and HTTP ETags to detect collisions.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPutRequiresIfMatch() throws URISyntaxException {
-        skipIfMethodNotAllowed(HttpMethod.PUT);
+	@Test(
+			groups = {SHOULD},
+			description = "LDP clients SHOULD use the HTTP If-Match header and HTTP ETags "
+					+ "to ensure it isn’t modifying a resource that has changed since the "
+					+ "client last retrieved its representation. LDP servers SHOULD require "
+					+ "the HTTP If-Match header and HTTP ETags to detect collisions.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPutRequiresIfMatch() throws URISyntaxException {
+		skipIfMethodNotAllowed(HttpMethod.PUT);
 
-        String resourceUri = getResourceUri();
-        Response response = buildBaseRequestSpecification()
-            .expect()
-                .statusCode(isSuccessful())
-                .header(ETAG, isValidEntityTag())
-            .when()
-                .get(resourceUri);
+		String resourceUri = getResourceUri();
+		Response response = buildBaseRequestSpecification()
+			.expect()
+				.statusCode(isSuccessful())
+				.header(ETAG, isValidEntityTag())
+			.when()
+				.get(resourceUri);
 
-        buildBaseRequestSpecification()
-                .contentType(response.getContentType())
-                .body(response.asByteArray())
-            .expect()
-                .statusCode(not(isSuccessful()))
-            .when()
-                .put(resourceUri);
-    }
+		buildBaseRequestSpecification()
+				.contentType(response.getContentType())
+				.body(response.asByteArray())
+			.expect()
+				.statusCode(not(isSuccessful()))
+			.when()
+				.put(resourceUri);
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers MUST respond with status code 412 "
-                    + "(Condition Failed) if ETags fail to match when there "
-                    + "are no other errors with the request [HTTP11]. LDP "
-                    + "servers that require conditional requests MUST respond "
-                    + "with status code 428 (Precondition Required) when the "
-                    + "absence of a precondition is the only reason for rejecting "
-                    + "the request [RFC6585].")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testConditionFailedStatusCode() {
-        skipIfMethodNotAllowed(HttpMethod.PUT);
+	@Test(
+			groups = {MUST},
+			description = "LDP servers MUST respond with status code 412 "
+					+ "(Condition Failed) if ETags fail to match when there "
+					+ "are no other errors with the request [HTTP11]. LDP "
+					+ "servers that require conditional requests MUST respond "
+					+ "with status code 428 (Precondition Required) when the "
+					+ "absence of a precondition is the only reason for rejecting "
+					+ "the request [RFC6585].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testConditionFailedStatusCode() {
+		skipIfMethodNotAllowed(HttpMethod.PUT);
 
-        String resourceUri = getResourceUri();
-        Response response = buildBaseRequestSpecification()
-                .expect()
-                    .statusCode(isSuccessful()).header(ETAG, isValidEntityTag())
-                .when()
-                    .get(resourceUri);
-        String contentType = response.getContentType();
+		String resourceUri = getResourceUri();
+		Response response = buildBaseRequestSpecification()
+				.expect()
+					.statusCode(isSuccessful()).header(ETAG, isValidEntityTag())
+				.when()
+					.get(resourceUri);
+		String contentType = response.getContentType();
 
-        buildBaseRequestSpecification()
-                    .contentType(contentType)
-                    .header(IF_MATCH, "These aren't the ETags you're looking for.")
-                    .body(response.asByteArray())
-                .expect()
-                    .statusCode(HttpStatus.SC_PRECONDITION_FAILED)
-                .when()
-                    .put(resourceUri);
-    }
+		buildBaseRequestSpecification()
+					.contentType(contentType)
+					.header(IF_MATCH, "These aren't the ETags you're looking for.")
+					.body(response.asByteArray())
+				.expect()
+					.statusCode(HttpStatus.SC_PRECONDITION_FAILED)
+				.when()
+					.put(resourceUri);
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers MUST respond with status code 412 "
-                    + "(Condition Failed) if ETags fail to match when there "
-                    + "are no other errors with the request [HTTP11]. LDP "
-                    + "servers that require conditional requests MUST respond "
-                    + "with status code 428 (Precondition Required) when the "
-                    + "absence of a precondition is the only reason for rejecting "
-                    + "the request [RFC6585].")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPreconditionRequiredStatusCode() {
-        skipIfMethodNotAllowed(HttpMethod.PUT);
+	@Test(
+			groups = {MUST},
+			description = "LDP servers MUST respond with status code 412 "
+					+ "(Condition Failed) if ETags fail to match when there "
+					+ "are no other errors with the request [HTTP11]. LDP "
+					+ "servers that require conditional requests MUST respond "
+					+ "with status code 428 (Precondition Required) when the "
+					+ "absence of a precondition is the only reason for rejecting "
+					+ "the request [RFC6585].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPreconditionRequiredStatusCode() {
+		skipIfMethodNotAllowed(HttpMethod.PUT);
 
-        String resourceUri = getResourceUri();
-        Response getResponse = buildBaseRequestSpecification()
-                .expect()
-                .statusCode(isSuccessful())
-                .header(ETAG, isValidEntityTag())
-                .when()
-                .get(resourceUri);
-        
-        // Verify that we can successfully PUT the resource WITH an If-Match header.
-        Response ifMatchResponse = buildBaseRequestSpecification()
-                    .header(IF_MATCH, getResponse.getHeader(ETAG))
-                    .contentType(getResponse.contentType())
-                    .body(getResponse.asByteArray())
-                .when()
-                    .put(resourceUri);
-        if (!isSuccessful().matches(ifMatchResponse.getStatusCode())) {
-            throw new SkipException("Skipping test because PUT request failed with valid If-Match header.");
-        }
+		String resourceUri = getResourceUri();
+		Response getResponse = buildBaseRequestSpecification()
+				.expect()
+				.statusCode(isSuccessful())
+				.header(ETAG, isValidEntityTag())
+				.when()
+				.get(resourceUri);
 
-        // Now try WITHOUT the If-Match header. If the result is NOT successful,
-        // it should be because the header is missing and we can check the error
-        // code.
-        Response noIfMatchResponse = buildBaseRequestSpecification()
-                    .contentType(getResponse.contentType())
-                    .body(getResponse.asByteArray())
-                .when()
-                    .put(resourceUri);
-        if (isSuccessful().matches(noIfMatchResponse.getStatusCode())) {
-            // It worked. This server doesn't require If-Match, which is only a
-            // SHOULD requirement (see testPutRequiresIfMatch). Skip the test.
-            throw new SkipException("Server does not require If-Match header.");
-        }
-        
-        assertEquals(428, noIfMatchResponse.getStatusCode(), "Expected 428 Precondition Required error on PUT request with no If-Match header");
-    }
+		// Verify that we can successfully PUT the resource WITH an If-Match header.
+		Response ifMatchResponse = buildBaseRequestSpecification()
+					.header(IF_MATCH, getResponse.getHeader(ETAG))
+					.contentType(getResponse.contentType())
+					.body(getResponse.asByteArray())
+				.when()
+					.put(resourceUri);
+		if (!isSuccessful().matches(ifMatchResponse.getStatusCode())) {
+			throw new SkipException("Skipping test because PUT request failed with valid If-Match header.");
+		}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers MUST respond with status code 412 "
-                    + "(Condition Failed) if ETags fail to match when there "
-                    + "are no other errors with the request [HTTP11]. LDP "
-                    + "servers that require conditional requests MUST respond "
-                    + "with status code 428 (Precondition Required) when the "
-                    + "absence of a precondition is the only reason for rejecting "
-                    + "the request [RFC6585].")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPutBadETag() {
-        skipIfMethodNotAllowed(HttpMethod.PUT);
+		// Now try WITHOUT the If-Match header. If the result is NOT successful,
+		// it should be because the header is missing and we can check the error
+		// code.
+		Response noIfMatchResponse = buildBaseRequestSpecification()
+					.contentType(getResponse.contentType())
+					.body(getResponse.asByteArray())
+				.when()
+					.put(resourceUri);
+		if (isSuccessful().matches(noIfMatchResponse.getStatusCode())) {
+			// It worked. This server doesn't require If-Match, which is only a
+			// SHOULD requirement (see testPutRequiresIfMatch). Skip the test.
+			throw new SkipException("Server does not require If-Match header.");
+		}
 
-        String resourceUri = getResourceUri();
-        Response response = buildBaseRequestSpecification()
-            .expect()
-                .statusCode(isSuccessful()).header(ETAG, isValidEntityTag())
-            .when()
-                .get(resourceUri);
+		assertEquals(428, noIfMatchResponse.getStatusCode(), "Expected 428 Precondition Required error on PUT request with no If-Match header");
+	}
 
-        buildBaseRequestSpecification()
-                .contentType(response.getContentType())
-                .header(IF_MATCH, "\"This is not the ETag you're looking for\"") // bad ETag value
-                .body(response.asByteArray())
-            .expect()
-                .statusCode(HttpStatus.SC_PRECONDITION_FAILED)
-            .when()
-                .put(resourceUri);
-    }
+	@Test(
+			groups = {MUST},
+			description = "LDP servers MUST respond with status code 412 "
+					+ "(Condition Failed) if ETags fail to match when there "
+					+ "are no other errors with the request [HTTP11]. LDP "
+					+ "servers that require conditional requests MUST respond "
+					+ "with status code 428 (Precondition Required) when the "
+					+ "absence of a precondition is the only reason for rejecting "
+					+ "the request [RFC6585].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-precond",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPutBadETag() {
+		skipIfMethodNotAllowed(HttpMethod.PUT);
 
-    @Test(
-            // enabled = false,
-            groups = {MUST},
-            description = "LDP servers MUST support the HTTP HEAD method. ")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-head-must",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testHead() {
-        assertTrue(supports(HttpMethod.HEAD), "HTTP HEAD is not listed in the Allow response header on HTTP OPTIONS requests for resource <" + getResourceUri() + ">");
-        buildBaseRequestSpecification().expect().statusCode(isSuccessful()).when().head(getResourceUri());
-    }
+		String resourceUri = getResourceUri();
+		Response response = buildBaseRequestSpecification()
+			.expect()
+				.statusCode(isSuccessful()).header(ETAG, isValidEntityTag())
+			.when()
+				.get(resourceUri);
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers that support PATCH MUST include an "
-                    + "Accept-Patch HTTP response header [RFC5789] on HTTP "
-                    + "OPTIONS requests, listing patch document media type(s) "
-                    + "supported by the server. ")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-patch-acceptpatch",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testAcceptPatchHeader() {
-        skipIfMethodNotAllowed(HttpMethod.PATCH);
+		buildBaseRequestSpecification()
+				.contentType(response.getContentType())
+				.header(IF_MATCH, "\"This is not the ETag you're looking for\"") // bad ETag value
+				.body(response.asByteArray())
+			.expect()
+				.statusCode(HttpStatus.SC_PRECONDITION_FAILED)
+			.when()
+				.put(resourceUri);
+	}
 
-        buildBaseRequestSpecification()
-                .expect().statusCode(isSuccessful()).header(ACCEPT_PATCH, notNullValue())
-                .when().options(getResourceUri());
-    }
+	@Test(
+			// enabled = false,
+			groups = {MUST},
+			description = "LDP servers MUST support the HTTP HEAD method. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-head-must",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testHead() {
+		assertTrue(supports(HttpMethod.HEAD), "HTTP HEAD is not listed in the Allow response header on HTTP OPTIONS requests for resource <" + getResourceUri() + ">");
+		buildBaseRequestSpecification().expect().statusCode(isSuccessful()).when().head(getResourceUri());
+	}
 
-    @Test(
-            // enabled = false,
-            groups = {MUST},
-            description = "LDP servers MUST support the HTTP OPTIONS method. ")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-options-must",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testOptions() {
-        buildBaseRequestSpecification().expect().statusCode(isSuccessful()).when().options(getResourceUri());
-    }
+	@Test(
+			groups = {MUST},
+			description = "LDP servers that support PATCH MUST include an "
+					+ "Accept-Patch HTTP response header [RFC5789] on HTTP "
+					+ "OPTIONS requests, listing patch document media type(s) "
+					+ "supported by the server. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-patch-acceptpatch",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testAcceptPatchHeader() {
+		skipIfMethodNotAllowed(HttpMethod.PATCH);
 
-    @Test(
-            // enabled = false,
-            groups = {MUST},
-            description = "LDP servers MUST indicate their support for HTTP Methods "
-                    + "by responding to a HTTP OPTIONS request on the LDPR’s URL "
-                    + "with the HTTP Method tokens in the HTTP response header Allow. ")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "ldpr-options-allow",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testOptionsAllowHeader() {
-        buildBaseRequestSpecification().expect().statusCode(isSuccessful()).header(ALLOW, notNullValue())
-                .when().options(getResourceUri());
-    }
-    
-    protected boolean supports(HttpMethod method) {
-        return options.contains(method.getName());
-    }
+		buildBaseRequestSpecification()
+				.expect().statusCode(isSuccessful()).header(ACCEPT_PATCH, notNullValue())
+				.when().options(getResourceUri());
+	}
 
-    protected void skipIfMethodNotAllowed(HttpMethod method) {
-        if (!supports(method)) {
-            throw new SkipMethodNotAllowedException(getResourceUri(), method);
-        }
-    }
+	@Test(
+			// enabled = false,
+			groups = {MUST},
+			description = "LDP servers MUST support the HTTP OPTIONS method. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-options-must",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testOptions() {
+		buildBaseRequestSpecification().expect().statusCode(isSuccessful()).when().options(getResourceUri());
+	}
+
+	@Test(
+			// enabled = false,
+			groups = {MUST},
+			description = "LDP servers MUST indicate their support for HTTP Methods "
+					+ "by responding to a HTTP OPTIONS request on the LDPR’s URL "
+					+ "with the HTTP Method tokens in the HTTP response header Allow. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "ldpr-options-allow",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testOptionsAllowHeader() {
+		buildBaseRequestSpecification().expect().statusCode(isSuccessful()).header(ALLOW, notNullValue())
+				.when().options(getResourceUri());
+	}
+
+	protected boolean supports(HttpMethod method) {
+		return options.contains(method.getName());
+	}
+
+	protected void skipIfMethodNotAllowed(HttpMethod method) {
+		if (!supports(method)) {
+			throw new SkipMethodNotAllowedException(getResourceUri(), method);
+		}
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/test/DirectContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/DirectContainerTest.java
@@ -27,346 +27,346 @@ import static org.testng.Assert.*;
 import static org.w3.ldp.testsuite.matcher.HttpStatusSuccessMatcher.isSuccessful;
 
 public class DirectContainerTest extends CommonContainerTest {
-    private String directContainer;
+	private String directContainer;
 
-    @Parameters({"directContainer", "auth"})
-    public DirectContainerTest(@Optional String directContainer, @Optional String auth) throws IOException {
-        super(auth);
-        this.directContainer = directContainer;
-    }
+	@Parameters({"directContainer", "auth"})
+	public DirectContainerTest(@Optional String directContainer, @Optional String auth) throws IOException {
+		super(auth);
+		this.directContainer = directContainer;
+	}
 
-    @BeforeClass(alwaysRun = true)
-    public void hasDirectContainer() {
-        if (directContainer == null) {
-            throw new SkipException("No directContainer parameter provided in testng.xml. Skipping ldp:DirectContainer tests.");
-        }
-    }
+	@BeforeClass(alwaysRun = true)
+	public void hasDirectContainer() {
+		if (directContainer == null) {
+			throw new SkipException("No directContainer parameter provided in testng.xml. Skipping ldp:DirectContainer tests.");
+		}
+	}
 
-    // MUST: 4.2.8.2 LDP servers must indicate their support for HTTP Methods by
-    // responding to a HTTP OPTIONS request on the LDPR's URL with the HTTP
-    // Method tokens in the HTTP response header Allow.
+	// MUST: 4.2.8.2 LDP servers must indicate their support for HTTP Methods by
+	// responding to a HTTP OPTIONS request on the LDPR's URL with the HTTP
+	// Method tokens in the HTTP response header Allow.
 
-    // MUST: 5.2.1.2 The representation of an LDPC may have an rdf:type of only
-    // one of ldp:Container for Linked Data Platform Container.
+	// MUST: 5.2.1.2 The representation of an LDPC may have an rdf:type of only
+	// one of ldp:Container for Linked Data Platform Container.
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers exposing LDPCs MUST advertise their "
-                    + "LDP support by exposing a HTTP Link header with a "
-                    + "target URI matching the type of container (see below) "
-                    + "the server supports, and a link relation type of type "
-                    + "(that is, rel='type') in all responses to requests made "
-                    + "to the LDPC's HTTP Request-URI.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testHttpLinkHeader() {
-        Response response = buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
-                .expect().statusCode(HttpStatus.SC_OK).when()
-                .get(directContainer);
-        assertTrue(
-                containsLinkHeader(LDP.DirectContainer.stringValue(), LINK_REL_TYPE, response),
-                "LDP DirectContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <" + LDP.DirectContainer.stringValue() + "> and rel='type'");
-    }
+	@Test(
+			groups = {MUST},
+			description = "LDP servers exposing LDPCs MUST advertise their "
+					+ "LDP support by exposing a HTTP Link header with a "
+					+ "target URI matching the type of container (see below) "
+					+ "the server supports, and a link relation type of type "
+					+ "(that is, rel='type') in all responses to requests made "
+					+ "to the LDPC's HTTP Request-URI.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testHttpLinkHeader() {
+		Response response = buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
+				.expect().statusCode(HttpStatus.SC_OK).when()
+				.get(directContainer);
+		assertTrue(
+				containsLinkHeader(LDP.DirectContainer.stringValue(), LINK_REL_TYPE, response),
+				"LDP DirectContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <" + LDP.DirectContainer.stringValue() + "> and rel='type'");
+	}
 
-    @Test(
-            groups = {SHOULD, "ldpMember"},
-            description = "LDP Direct Containers SHOULD use the ldp:member predicate "
-                    + "as an LDPC's membership predicate if there is no obvious "
-                    + "predicate from an application vocabulary to use.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-mbrpred",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testUseMemberPredicate() throws URISyntaxException {
-        Model containerModel = getAsModel(directContainer);
-        Resource container = containerModel.getResource(directContainer);
-        if (container.hasProperty(containerModel.createProperty(LDP.isMemberOfRelation.stringValue()))) {
-            throw new SkipException("This test does not apply to containers using the ldp:isMemberOfRelation membership pattern.");
-        }
-        Resource hasMemberRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.hasMemberRelation.stringValue()));
-        assertEquals(LDP.member.stringValue(), hasMemberRelation.getURI(), "LDP Direct Containers should use the ldp:member predicate if "
-                + "there is no obvious predicate from the application vocabulary. You can disable this test using the 'testLdpMember' parameter in testng.xml.");
-    }
+	@Test(
+			groups = {SHOULD, "ldpMember"},
+			description = "LDP Direct Containers SHOULD use the ldp:member predicate "
+					+ "as an LDPC's membership predicate if there is no obvious "
+					+ "predicate from an application vocabulary to use.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-mbrpred",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testUseMemberPredicate() throws URISyntaxException {
+		Model containerModel = getAsModel(directContainer);
+		Resource container = containerModel.getResource(directContainer);
+		if (container.hasProperty(containerModel.createProperty(LDP.isMemberOfRelation.stringValue()))) {
+			throw new SkipException("This test does not apply to containers using the ldp:isMemberOfRelation membership pattern.");
+		}
+		Resource hasMemberRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.hasMemberRelation.stringValue()));
+		assertEquals(LDP.member.stringValue(), hasMemberRelation.getURI(), "LDP Direct Containers should use the ldp:member predicate if "
+				+ "there is no obvious predicate from the application vocabulary. You can disable this test using the 'testLdpMember' parameter in testng.xml.");
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "Each LDP Direct Container representation MUST contain exactly "
-                    + "one triple whose subject is the LDPC URI, whose predicate is the "
-                    + "ldp:membershipResource, and whose object is the LDPC's membership-"
-                    + "constant-URI. Commonly the LDPC's URI is the membership-constant-URI,"
-                    + " but LDP does not require this.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-containres",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testMemberResourceTriple() throws URISyntaxException {
-        Model containerModel = getAsModel(directContainer);
-        Resource container = containerModel.getResource(directContainer);
-        Resource membershipResource = container.getPropertyResourceValue(containerModel.createProperty(LDP.membershipResource.stringValue()));
-        assertNotNull(membershipResource);
-    }
+	@Test(
+			groups = {MUST},
+			description = "Each LDP Direct Container representation MUST contain exactly "
+					+ "one triple whose subject is the LDPC URI, whose predicate is the "
+					+ "ldp:membershipResource, and whose object is the LDPC's membership-"
+					+ "constant-URI. Commonly the LDPC's URI is the membership-constant-URI,"
+					+ " but LDP does not require this.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-containres",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testMemberResourceTriple() throws URISyntaxException {
+		Model containerModel = getAsModel(directContainer);
+		Resource container = containerModel.getResource(directContainer);
+		Resource membershipResource = container.getPropertyResourceValue(containerModel.createProperty(LDP.membershipResource.stringValue()));
+		assertNotNull(membershipResource);
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "Each LDP Direct Container representation must contain exactly "
-                    + "one triple whose subject is the LDPC URI, and whose predicate "
-                    + "is either ldp:hasMemberRelation or ldp:isMemberOfRelation. "
-                    + "The object of the triple is constrained by other sections, "
-                    + "such as ldp:hasMemberRelation or ldp:isMemberOfRelation, "
-                    + "based on the membership triple pattern used by the container.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-containtriples",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testMemberRelationOrIsMemberOfRelationTripleExists() throws URISyntaxException {
-        Model containerModel = getAsModel(directContainer);
-        Resource container = containerModel.getResource(directContainer);
-        Resource hasMemberRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.hasMemberRelation.stringValue()));
-        Resource isMemberOfRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.isMemberOfRelation.stringValue()));
-        if (hasMemberRelation == null) {
-            assertNotNull(isMemberOfRelation, "LDP DirectContainer must have either ldp:hasMemberRelation or ldp:isMemberOfRelation");
-        } else {
-            assertNull(isMemberOfRelation, "LDP DirectContainer cannot have both ldp:hasMemberRelation and ldp:isMemberOfRelation");
-        }
-    }
+	@Test(
+			groups = {MUST},
+			description = "Each LDP Direct Container representation must contain exactly "
+					+ "one triple whose subject is the LDPC URI, and whose predicate "
+					+ "is either ldp:hasMemberRelation or ldp:isMemberOfRelation. "
+					+ "The object of the triple is constrained by other sections, "
+					+ "such as ldp:hasMemberRelation or ldp:isMemberOfRelation, "
+					+ "based on the membership triple pattern used by the container.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-containtriples",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testMemberRelationOrIsMemberOfRelationTripleExists() throws URISyntaxException {
+		Model containerModel = getAsModel(directContainer);
+		Resource container = containerModel.getResource(directContainer);
+		Resource hasMemberRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.hasMemberRelation.stringValue()));
+		Resource isMemberOfRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.isMemberOfRelation.stringValue()));
+		if (hasMemberRelation == null) {
+			assertNotNull(isMemberOfRelation, "LDP DirectContainer must have either ldp:hasMemberRelation or ldp:isMemberOfRelation");
+		} else {
+			assertNull(isMemberOfRelation, "LDP DirectContainer cannot have both ldp:hasMemberRelation and ldp:isMemberOfRelation");
+		}
+	}
 
-    @Test(
-            groups = {MUST},
-            enabled = false, // not implemented
-            description = "LDP Direct Containers MUST behave as if they have a "
-                    + "(LDPC URI, ldp:insertedContentRelation , ldp:MemberSubject)"
-                    + " triple, but LDP imposes no requirement to materialize such "
-                    + "a triple in the LDP-DC representation.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-indirectmbr-basic",
-            testMethod = METHOD.NOT_IMPLEMENTED,
-            approval = STATUS.WG_PENDING)
-    public void testActAsIfInsertedContentRelationTripleExists() {
-        // TODO: Impl testActAsIfInsertedContentRelationTripleExists
-    }
+	@Test(
+			groups = {MUST},
+			enabled = false, // not implemented
+			description = "LDP Direct Containers MUST behave as if they have a "
+					+ "(LDPC URI, ldp:insertedContentRelation , ldp:MemberSubject)"
+					+ " triple, but LDP imposes no requirement to materialize such "
+					+ "a triple in the LDP-DC representation.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-indirectmbr-basic",
+			testMethod = METHOD.NOT_IMPLEMENTED,
+			approval = STATUS.WG_PENDING)
+	public void testActAsIfInsertedContentRelationTripleExists() {
+		// TODO: Impl testActAsIfInsertedContentRelationTripleExists
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "When a successful HTTP POST request to an LDPC results "
-                    + "in the creation of an LDPR, the LDPC MUST update its "
-                    + "membership triples to reflect that addition, and the resulting "
-                    + "membership triple MUST be consistent with any LDP-defined "
-                    + "predicates it exposes.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-post-createdmbr-member",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPostResourceUpdatesTriples() {
-        skipIfMethodNotAllowed(HttpMethod.POST);
+	@Test(
+			groups = {MUST},
+			description = "When a successful HTTP POST request to an LDPC results "
+					+ "in the creation of an LDPR, the LDPC MUST update its "
+					+ "membership triples to reflect that addition, and the resulting "
+					+ "membership triple MUST be consistent with any LDP-defined "
+					+ "predicates it exposes.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-post-createdmbr-member",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPostResourceUpdatesTriples() {
+		skipIfMethodNotAllowed(HttpMethod.POST);
 
-        Model model = postContent();
-        Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE).body(model, new RdfObjectMapper())
-                .expect().statusCode(HttpStatus.SC_CREATED).header(LOCATION, notNullValue())
-                .when().post(directContainer);
+		Model model = postContent();
+		Response postResponse = buildBaseRequestSpecification().contentType(TEXT_TURTLE).body(model, new RdfObjectMapper())
+				.expect().statusCode(HttpStatus.SC_CREATED).header(LOCATION, notNullValue())
+				.when().post(directContainer);
 
-        String location = postResponse.getHeader(LOCATION);
-        Response getResponse = buildBaseRequestSpecification()
-                    .header(ACCEPT, TEXT_TURTLE)
-                    .header(PREFER, include(PREFER_MEMBERSHIP)) // request all membership triples
-                .expect()
-                    .statusCode(isSuccessful())
-                .when()
-                    .get(directContainer);
-        Model containerModel = getResponse.as(Model.class, new RdfObjectMapper(directContainer));
-        Resource container = containerModel.getResource(directContainer);
-        Resource membershipResource = container.getPropertyResourceValue(containerModel.createProperty(LDP.membershipResource.stringValue()));
-        Resource hasMemberRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.hasMemberRelation.stringValue()));
-        assertNotNull(membershipResource);
+		String location = postResponse.getHeader(LOCATION);
+		Response getResponse = buildBaseRequestSpecification()
+					.header(ACCEPT, TEXT_TURTLE)
+					.header(PREFER, include(PREFER_MEMBERSHIP)) // request all membership triples
+				.expect()
+					.statusCode(isSuccessful())
+				.when()
+					.get(directContainer);
+		Model containerModel = getResponse.as(Model.class, new RdfObjectMapper(directContainer));
+		Resource container = containerModel.getResource(directContainer);
+		Resource membershipResource = container.getPropertyResourceValue(containerModel.createProperty(LDP.membershipResource.stringValue()));
+		Resource hasMemberRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.hasMemberRelation.stringValue()));
+		assertNotNull(membershipResource);
 
-        if (hasMemberRelation != null) {
-            // Make sure the resource is a member of the container.
-            assertTrue(membershipResource.hasProperty(containerModel.createProperty(hasMemberRelation.getURI()), containerModel.createResource(location)));
-        }
+		if (hasMemberRelation != null) {
+			// Make sure the resource is a member of the container.
+			assertTrue(membershipResource.hasProperty(containerModel.createProperty(hasMemberRelation.getURI()), containerModel.createResource(location)));
+		}
 
-        // Delete the resource to clean up.
-        buildBaseRequestSpecification().delete(location);
-    }
+		// Delete the resource to clean up.
+		buildBaseRequestSpecification().delete(location);
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "When an LDPR identified by the object of a membership "
-                    + "triple which was originally created by the LDP-DC is deleted, "
-                    + "the LDPC server MUST also remove the corresponding membership triple.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-del-contremovesmbrtriple",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testDeleteResourceUpdatesTriples() {
-        skipIfMethodNotAllowed(HttpMethod.POST);
+	@Test(
+			groups = {MUST},
+			description = "When an LDPR identified by the object of a membership "
+					+ "triple which was originally created by the LDP-DC is deleted, "
+					+ "the LDPC server MUST also remove the corresponding membership triple.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpdc-del-contremovesmbrtriple",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testDeleteResourceUpdatesTriples() {
+		skipIfMethodNotAllowed(HttpMethod.POST);
 
-        // Create a resource.
-        Model model = postContent();
-        Response postResponse = buildBaseRequestSpecification()
-                .contentType(TEXT_TURTLE)
-                .body(model, new RdfObjectMapper())
-            .expect()
-                .statusCode(HttpStatus.SC_CREATED)
-                .header(LOCATION, HeaderMatchers.headerPresent())
-            .when()
-                .post(directContainer);
+		// Create a resource.
+		Model model = postContent();
+		Response postResponse = buildBaseRequestSpecification()
+				.contentType(TEXT_TURTLE)
+				.body(model, new RdfObjectMapper())
+			.expect()
+				.statusCode(HttpStatus.SC_CREATED)
+				.header(LOCATION, HeaderMatchers.headerPresent())
+			.when()
+				.post(directContainer);
 
-        String location = postResponse.getHeader(LOCATION);
+		String location = postResponse.getHeader(LOCATION);
 
-        // Test the membership triple
-        Response getResponse = buildBaseRequestSpecification()
-                    .header(ACCEPT, TEXT_TURTLE)
-                    .header(PREFER, include(PREFER_MEMBERSHIP)) // request all membership triple regardless of membership patterns
-                .expect()
-                    .statusCode(isSuccessful())
-                .when()
-                    .get(directContainer);
-        Model containerModel = getResponse.as(Model.class, new RdfObjectMapper(directContainer));
+		// Test the membership triple
+		Response getResponse = buildBaseRequestSpecification()
+					.header(ACCEPT, TEXT_TURTLE)
+					.header(PREFER, include(PREFER_MEMBERSHIP)) // request all membership triple regardless of membership patterns
+				.expect()
+					.statusCode(isSuccessful())
+				.when()
+					.get(directContainer);
+		Model containerModel = getResponse.as(Model.class, new RdfObjectMapper(directContainer));
 
-        Resource container = containerModel.getResource(directContainer);
-        Resource membershipResource = container.getPropertyResourceValue(containerModel.createProperty(LDP.membershipResource.stringValue()));
-        Resource hasMemberRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.hasMemberRelation.stringValue()));
-        Resource isMemberOfRelation = null;
-        assertNotNull(membershipResource, MSG_MBRRES_NOTFOUND);
+		Resource container = containerModel.getResource(directContainer);
+		Resource membershipResource = container.getPropertyResourceValue(containerModel.createProperty(LDP.membershipResource.stringValue()));
+		Resource hasMemberRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.hasMemberRelation.stringValue()));
+		Resource isMemberOfRelation = null;
+		assertNotNull(membershipResource, MSG_MBRRES_NOTFOUND);
 
-        // First verify the membership triples exist
-        if (hasMemberRelation != null) {
-            assertTrue(membershipResource.hasProperty(containerModel.createProperty(hasMemberRelation.getURI()), containerModel.getResource(location)),
-                    "The LDPC server must have a corresponding membership triple when an LDPR is added (hasMemberRelation).");
-        } else {
-            // Not if membership triple is not of form: (container, membership predicate, member), it may be the inverse.
-            isMemberOfRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.isMemberOfRelation.stringValue()));
-            // Check the container for the triple.
-            if (!containerModel.contains(containerModel.getResource(location), containerModel.createProperty(isMemberOfRelation.getURI()), membershipResource)) {
-                assertFalse(
-                        isPreferenceApplied(getResponse),
-                        "Server responded with Preference-Applied header for including membership triples, but membership triple is missing.");
-            }
- 
-            // Check the resource has the triple as well.
-            Model memberResourceModel = getAsModel(location);
-            assertTrue(memberResourceModel.contains(memberResourceModel.getResource(location), memberResourceModel.createProperty(isMemberOfRelation.getURI()), membershipResource),
-                    "The LDPC server must have a corresponding membership triple when an LDPR is added (isMemberOfRelation).");
-        }
+		// First verify the membership triples exist
+		if (hasMemberRelation != null) {
+			assertTrue(membershipResource.hasProperty(containerModel.createProperty(hasMemberRelation.getURI()), containerModel.getResource(location)),
+					"The LDPC server must have a corresponding membership triple when an LDPR is added (hasMemberRelation).");
+		} else {
+			// Not if membership triple is not of form: (container, membership predicate, member), it may be the inverse.
+			isMemberOfRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.isMemberOfRelation.stringValue()));
+			// Check the container for the triple.
+			if (!containerModel.contains(containerModel.getResource(location), containerModel.createProperty(isMemberOfRelation.getURI()), membershipResource)) {
+				assertFalse(
+						isPreferenceApplied(getResponse),
+						"Server responded with Preference-Applied header for including membership triples, but membership triple is missing.");
+			}
 
-        // Delete the resource
-        buildBaseRequestSpecification().expect().statusCode(isSuccessful()).when().delete(location);
+			// Check the resource has the triple as well.
+			Model memberResourceModel = getAsModel(location);
+			assertTrue(memberResourceModel.contains(memberResourceModel.getResource(location), memberResourceModel.createProperty(isMemberOfRelation.getURI()), membershipResource),
+					"The LDPC server must have a corresponding membership triple when an LDPR is added (isMemberOfRelation).");
+		}
 
-        // Get the updated membership resource
-        getResponse = buildBaseRequestSpecification()
-                    .header(ACCEPT, TEXT_TURTLE)
-                    .header(PREFER, include(PREFER_MEMBERSHIP)) // request all membership triple regardless of membership patterns
-                .expect()
-                    .statusCode(isSuccessful())
-                .when()
-                    .get(directContainer);
-        containerModel = getResponse.as(Model.class, new RdfObjectMapper(directContainer));
-        membershipResource = containerModel.getResource(membershipResource.getURI());
+		// Delete the resource
+		buildBaseRequestSpecification().expect().statusCode(isSuccessful()).when().delete(location);
 
-        // Now verify the membership triples DON"T exist
-        if (hasMemberRelation != null) {
-            assertFalse(membershipResource.hasProperty(containerModel.createProperty(hasMemberRelation.getURI()), containerModel.getResource(location)),
-                    "The LDPC server must remove the corresponding membership triple when an LDPR is deleted (hasMemberRelation).");
-        } else {
-            // Not if membership triple is not of form: (container, membership predicate, member), it may be the inverse.
-            isMemberOfRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.isMemberOfRelation.stringValue()));
-            assertFalse(containerModel.contains(containerModel.getResource(location), containerModel.createProperty(isMemberOfRelation.getURI()), membershipResource),
-                    "The LDPC server must remove the corresponding membership triple when an LDPR is deleted (isMemberOfRelation).");
-        }
-    }
-    
-    private boolean hasMembershipTriples(Model containerModel) {
-        Resource container = containerModel.getResource(directContainer);
-        Resource membershipResource = container.getPropertyResourceValue(containerModel.createProperty(LDP.membershipResource.stringValue()));
-        Resource hasMemberRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.hasMemberRelation.stringValue()));
-        assertNotNull(membershipResource, MSG_MBRRES_NOTFOUND);
+		// Get the updated membership resource
+		getResponse = buildBaseRequestSpecification()
+					.header(ACCEPT, TEXT_TURTLE)
+					.header(PREFER, include(PREFER_MEMBERSHIP)) // request all membership triple regardless of membership patterns
+				.expect()
+					.statusCode(isSuccessful())
+				.when()
+					.get(directContainer);
+		containerModel = getResponse.as(Model.class, new RdfObjectMapper(directContainer));
+		membershipResource = containerModel.getResource(membershipResource.getURI());
 
-        // First verify the membership triples exist
-        if (hasMemberRelation != null) {
-            return membershipResource.hasProperty(containerModel.createProperty(hasMemberRelation.getURI()));
-        }
+		// Now verify the membership triples DON"T exist
+		if (hasMemberRelation != null) {
+			assertFalse(membershipResource.hasProperty(containerModel.createProperty(hasMemberRelation.getURI()), containerModel.getResource(location)),
+					"The LDPC server must remove the corresponding membership triple when an LDPR is deleted (hasMemberRelation).");
+		} else {
+			// Not if membership triple is not of form: (container, membership predicate, member), it may be the inverse.
+			isMemberOfRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.isMemberOfRelation.stringValue()));
+			assertFalse(containerModel.contains(containerModel.getResource(location), containerModel.createProperty(isMemberOfRelation.getURI()), membershipResource),
+					"The LDPC server must remove the corresponding membership triple when an LDPR is deleted (isMemberOfRelation).");
+		}
+	}
 
-        // Not if membership triple is not of form: (container, membership predicate, member), it may be the inverse.
-        Resource isMemberOfRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.isMemberOfRelation.stringValue()));
-        return containerModel.contains(null, containerModel.createProperty(isMemberOfRelation.getURI()), membershipResource);
-    }
- 
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers SHOULD respect all of a client's LDP-defined "
-                    + "hints, for example which subsets of LDP-defined state the "
-                    + "client is interested in processing, to influence the set of "
-                    + "triples returned in representations of an LDPC, particularly for "
-                    + "large LDPCs. See also [LDP-PAGING].")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-prefer",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testPreferMembershipTriples() {
-        Response response;
-        Model model;
+	private boolean hasMembershipTriples(Model containerModel) {
+		Resource container = containerModel.getResource(directContainer);
+		Resource membershipResource = container.getPropertyResourceValue(containerModel.createProperty(LDP.membershipResource.stringValue()));
+		Resource hasMemberRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.hasMemberRelation.stringValue()));
+		assertNotNull(membershipResource, MSG_MBRRES_NOTFOUND);
 
-        // Ask for membership triples.
-        response = buildBaseRequestSpecification()
-                    .header(ACCEPT, TEXT_TURTLE)
-                    .header(PREFER, include(PREFER_MEMBERSHIP)) // request all membership triples
-                .expect()
-                    .statusCode(isSuccessful())
-                .when()
-                    .get(directContainer);
-        model = response.as(Model.class, new RdfObjectMapper(directContainer));
+		// First verify the membership triples exist
+		if (hasMemberRelation != null) {
+			return membershipResource.hasProperty(containerModel.createProperty(hasMemberRelation.getURI()));
+		}
 
-        // Assumes the container is not empty.
-        assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
-        assertTrue(hasMembershipTriples(model), "Container does not have membership triples");
- 
-        // Ask for a minimal container.
-        response = buildBaseRequestSpecification()
-                    .header(ACCEPT, TEXT_TURTLE)
-                    .header(PREFER, include(PREFER_MINIMAL_CONTAINER)) // request no membership triples
-                .expect()
-                    .statusCode(isSuccessful())
-                .when()
-                    .get(directContainer);
-        model = response.as(Model.class, new RdfObjectMapper(directContainer));
+		// Not if membership triple is not of form: (container, membership predicate, member), it may be the inverse.
+		Resource isMemberOfRelation = container.getPropertyResourceValue(containerModel.createProperty(LDP.isMemberOfRelation.stringValue()));
+		return containerModel.contains(null, containerModel.createProperty(isMemberOfRelation.getURI()), membershipResource);
+	}
 
-        assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
-        assertFalse(hasMembershipTriples(model), "Container has membership triples when minimal container was requested");
- 
-        // Ask to omit membership.
-        response = buildBaseRequestSpecification()
-                    .header(ACCEPT, TEXT_TURTLE)
-                    .header(PREFER, omit(PREFER_MEMBERSHIP)) // request no membership triples
-                .expect()
-                    .statusCode(isSuccessful())
-                .when()
-                    .get(directContainer);
-        model = response.as(Model.class, new RdfObjectMapper(directContainer));
+	@Test(
+			groups = {SHOULD},
+			description = "LDP servers SHOULD respect all of a client's LDP-defined "
+					+ "hints, for example which subsets of LDP-defined state the "
+					+ "client is interested in processing, to influence the set of "
+					+ "triples returned in representations of an LDPC, particularly for "
+					+ "large LDPCs. See also [LDP-PAGING].")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-prefer",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testPreferMembershipTriples() {
+		Response response;
+		Model model;
 
-        assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
-        assertFalse(hasMembershipTriples(model), "Container has membership triples when client requested server omit them");
-        
-        // Ask for a minimal container, but include membership. (Example from spec.)
-        response = buildBaseRequestSpecification()
-                    .header(ACCEPT, TEXT_TURTLE)
-                    .header(PREFER, include(PREFER_MINIMAL_CONTAINER, PREFER_MEMBERSHIP))
-                .expect()
-                    .statusCode(isSuccessful())
-                .when()
-                    .get(directContainer);
-        model = response.as(Model.class, new RdfObjectMapper(directContainer));
+		// Ask for membership triples.
+		response = buildBaseRequestSpecification()
+					.header(ACCEPT, TEXT_TURTLE)
+					.header(PREFER, include(PREFER_MEMBERSHIP)) // request all membership triples
+				.expect()
+					.statusCode(isSuccessful())
+				.when()
+					.get(directContainer);
+		model = response.as(Model.class, new RdfObjectMapper(directContainer));
 
-        // Assumes the container is not empty.
-        assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
-        assertTrue(hasMembershipTriples(model), "Container does not have membership triples");
-        assertFalse(model.contains(model.getResource(directContainer), model.createProperty(LDP.contains.stringValue())),
-                "Container has containment triples when minimal container was requested");
-    }
+		// Assumes the container is not empty.
+		assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
+		assertTrue(hasMembershipTriples(model), "Container does not have membership triples");
 
-    @Override
-    protected String getResourceUri() {
-        return directContainer;
-    }
+		// Ask for a minimal container.
+		response = buildBaseRequestSpecification()
+					.header(ACCEPT, TEXT_TURTLE)
+					.header(PREFER, include(PREFER_MINIMAL_CONTAINER)) // request no membership triples
+				.expect()
+					.statusCode(isSuccessful())
+				.when()
+					.get(directContainer);
+		model = response.as(Model.class, new RdfObjectMapper(directContainer));
+
+		assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
+		assertFalse(hasMembershipTriples(model), "Container has membership triples when minimal container was requested");
+
+		// Ask to omit membership.
+		response = buildBaseRequestSpecification()
+					.header(ACCEPT, TEXT_TURTLE)
+					.header(PREFER, omit(PREFER_MEMBERSHIP)) // request no membership triples
+				.expect()
+					.statusCode(isSuccessful())
+				.when()
+					.get(directContainer);
+		model = response.as(Model.class, new RdfObjectMapper(directContainer));
+
+		assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
+		assertFalse(hasMembershipTriples(model), "Container has membership triples when client requested server omit them");
+
+		// Ask for a minimal container, but include membership. (Example from spec.)
+		response = buildBaseRequestSpecification()
+					.header(ACCEPT, TEXT_TURTLE)
+					.header(PREFER, include(PREFER_MINIMAL_CONTAINER, PREFER_MEMBERSHIP))
+				.expect()
+					.statusCode(isSuccessful())
+				.when()
+					.get(directContainer);
+		model = response.as(Model.class, new RdfObjectMapper(directContainer));
+
+		// Assumes the container is not empty.
+		assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
+		assertTrue(hasMembershipTriples(model), "Container does not have membership triples");
+		assertFalse(model.contains(model.getResource(directContainer), model.createProperty(LDP.contains.stringValue())),
+				"Container has containment triples when minimal container was requested");
+	}
+
+	@Override
+	protected String getResourceUri() {
+		return directContainer;
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/test/IndirectContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/IndirectContainerTest.java
@@ -19,100 +19,100 @@ import static org.testng.Assert.assertTrue;
 
 public class IndirectContainerTest extends CommonContainerTest {
 
-    private String indirectContainer;
+	private String indirectContainer;
 
-    @Parameters({"indirectContainer", "auth"})
-    public IndirectContainerTest(@Optional String indirectContainer, @Optional String auth) throws IOException {
-        super(auth);
-        this.indirectContainer = indirectContainer;
-    }
+	@Parameters({"indirectContainer", "auth"})
+	public IndirectContainerTest(@Optional String indirectContainer, @Optional String auth) throws IOException {
+		super(auth);
+		this.indirectContainer = indirectContainer;
+	}
 
-    @BeforeClass(alwaysRun = true)
-    public void hasIndirectContainer() {
-        if (indirectContainer == null) {
-            throw new SkipException(
-                    "No indirectContainer parameter provided in testng.xml. Skipping ldp:IndirectContainer tests.");
-        }
-    }
+	@BeforeClass(alwaysRun = true)
+	public void hasIndirectContainer() {
+		if (indirectContainer == null) {
+			throw new SkipException(
+					"No indirectContainer parameter provided in testng.xml. Skipping ldp:IndirectContainer tests.");
+		}
+	}
 
-    // TODO implement tests, signatures are from LDP spec
-    @Test(
-            groups = {MUST},
-            description = "LDP servers exposing LDPCs MUST advertise their "
-                    + "LDP support by exposing a HTTP Link header with a "
-                    + "target URI matching the type of container (see below) "
-                    + "the server supports, and a link relation type of type "
-                    + "(that is, rel='type') in all responses to requests made "
-                    + "to the LDPC's HTTP Request-URI.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testContainerSupportsHttpLinkHeader() {
-        Response response = buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
-                .expect().statusCode(HttpStatus.SC_OK).when()
-                .get(indirectContainer);
-        assertTrue(
-                containsLinkHeader(LDP.IndirectContainer.stringValue(), LINK_REL_TYPE,
-                        response),
-                "LDP DirectContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <"
-                        + LDP.IndirectContainer.stringValue()
-                        + "> and rel='type'"
-        );
-    }
+	// TODO implement tests, signatures are from LDP spec
+	@Test(
+			groups = {MUST},
+			description = "LDP servers exposing LDPCs MUST advertise their "
+					+ "LDP support by exposing a HTTP Link header with a "
+					+ "target URI matching the type of container (see below) "
+					+ "the server supports, and a link relation type of type "
+					+ "(that is, rel='type') in all responses to requests made "
+					+ "to the LDPC's HTTP Request-URI.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-linktypehdr",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testContainerSupportsHttpLinkHeader() {
+		Response response = buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
+				.expect().statusCode(HttpStatus.SC_OK).when()
+				.get(indirectContainer);
+		assertTrue(
+				containsLinkHeader(LDP.IndirectContainer.stringValue(), LINK_REL_TYPE,
+						response),
+				"LDP DirectContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <"
+						+ LDP.IndirectContainer.stringValue()
+						+ "> and rel='type'"
+		);
+	}
 
-    @Test(
-            groups = {MUST},
-            enabled = false,
-            description = "Each LDP Indirect Container MUST also be a conforming "
-                    + "LDP Direct Container in section 5.4 Direct along "
-                    + "the following restrictions.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpic-are-ldpcs",
-            testMethod = METHOD.NOT_IMPLEMENTED,
-            approval = STATUS.WG_PENDING)
-    public void testCreateIndirectContainer() {
-        // TODO: Impl testCreateIndirectContainer
-    }
+	@Test(
+			groups = {MUST},
+			enabled = false,
+			description = "Each LDP Indirect Container MUST also be a conforming "
+					+ "LDP Direct Container in section 5.4 Direct along "
+					+ "the following restrictions.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpic-are-ldpcs",
+			testMethod = METHOD.NOT_IMPLEMENTED,
+			approval = STATUS.WG_PENDING)
+	public void testCreateIndirectContainer() {
+		// TODO: Impl testCreateIndirectContainer
+	}
 
-    @Test(
-            groups = {MUST},
-            enabled = false,
-            description = "LDP Indirect Containers MUST contain exactly one "
-                    + "triple whose subject is the LDPC URI, whose predicate "
-                    + "is ldp:insertedContentRelation, and whose object ICR "
-                    + "describes how the member-derived-URI in the container's "
-                    + "membership triples is chosen.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpic-indirectmbr",
-            testMethod = METHOD.NOT_IMPLEMENTED,
-            approval = STATUS.WG_PENDING)
-    public void testContainsLdpcUri() {
-        // TODO: Impl testContainsLdpcUri
-    }
+	@Test(
+			groups = {MUST},
+			enabled = false,
+			description = "LDP Indirect Containers MUST contain exactly one "
+					+ "triple whose subject is the LDPC URI, whose predicate "
+					+ "is ldp:insertedContentRelation, and whose object ICR "
+					+ "describes how the member-derived-URI in the container's "
+					+ "membership triples is chosen.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpic-indirectmbr",
+			testMethod = METHOD.NOT_IMPLEMENTED,
+			approval = STATUS.WG_PENDING)
+	public void testContainsLdpcUri() {
+		// TODO: Impl testContainsLdpcUri
+	}
 
-    @Test(
-            groups = {MUST},
-            enabled = false,
-            description = "LDPCs whose ldp:insertedContentRelation triple has an "
-                    + "object other than ldp:MemberSubject and that create new "
-                    + "resources MUST add a triple to the container whose subject is "
-                    + "the container's URI, whose predicate is ldp:contains, and whose "
-                    + "object is the newly created resource's URI (which will be "
-                    + "different from the member-derived URI in this case). This "
-                    + "ldp:contains triple can be the only link from the container to the "
-                    + "newly created resource in certain cases.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpic-post-indirectmbrrel",
-            testMethod = METHOD.NOT_IMPLEMENTED,
-            approval = STATUS.WG_PENDING)
-    public void testPostResource() {
-        // TODO: Impl testPostResource
-    }
+	@Test(
+			groups = {MUST},
+			enabled = false,
+			description = "LDPCs whose ldp:insertedContentRelation triple has an "
+					+ "object other than ldp:MemberSubject and that create new "
+					+ "resources MUST add a triple to the container whose subject is "
+					+ "the container's URI, whose predicate is ldp:contains, and whose "
+					+ "object is the newly created resource's URI (which will be "
+					+ "different from the member-derived URI in this case). This "
+					+ "ldp:contains triple can be the only link from the container to the "
+					+ "newly created resource in certain cases.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpic-post-indirectmbrrel",
+			testMethod = METHOD.NOT_IMPLEMENTED,
+			approval = STATUS.WG_PENDING)
+	public void testPostResource() {
+		// TODO: Impl testPostResource
+	}
 
-    @Override
-    protected String getResourceUri() {
-        return indirectContainer;
-    }
+	@Override
+	protected String getResourceUri() {
+		return indirectContainer;
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import javax.ws.rs.core.Link;
 
-import com.jayway.restassured.specification.RequestSpecification;
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.resteasy.plugins.delegates.LinkDelegate;
 import org.testng.annotations.BeforeSuite;
@@ -21,210 +20,211 @@ import org.w3.ldp.testsuite.mapper.RdfObjectMapper;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 import com.hp.hpl.jena.rdf.model.Resource;
-import com.hp.hpl.jena.vocabulary.DC;
+import com.hp.hpl.jena.vocabulary.DC_11;
 import com.jayway.restassured.response.Header;
 import com.jayway.restassured.response.Response;
+import com.jayway.restassured.specification.RequestSpecification;
 
 public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences {
 
-    /**
-     * Alternate content to use on POST requests
-     */
-    protected String post;
+	/**
+	 * Alternate content to use on POST requests
+	 */
+	protected String post;
 
-    @BeforeSuite(alwaysRun = true)
-    @Parameters("post")
-    public void setPostContent(@Optional String post) {
-        this.post = post;
-    }
+	@BeforeSuite(alwaysRun = true)
+	@Parameters("post")
+	public void setPostContent(@Optional String post) {
+		this.post = post;
+	}
 
-    /**
-     * An absolute requirement of the specification.
-     *
-     * @see <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>
-     */
-    public static final String MUST = "MUST";
+	/**
+	 * An absolute requirement of the specification.
+	 *
+	 * @see <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>
+	 */
+	public static final String MUST = "MUST";
 
-    /**
-     * There may exist valid reasons in particular circumstances to ignore a
-     * particular item, but the full implications must be understood and
-     * carefully weighed before choosing a different course.
-     *
-     * @see <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>
-     */
-    public static final String SHOULD = "SHOULD";
+	/**
+	 * There may exist valid reasons in particular circumstances to ignore a
+	 * particular item, but the full implications must be understood and
+	 * carefully weighed before choosing a different course.
+	 *
+	 * @see <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>
+	 */
+	public static final String SHOULD = "SHOULD";
 
-    /**
-     * An item is truly optional. One vendor may choose to include the item
-     * because a particular marketplace requires it or because the vendor feels
-     * that it enhances the product while another vendor may omit the same item.
-     *
-     * @see <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>
-     */
-    public static final String MAY = "MAY";
+	/**
+	 * An item is truly optional. One vendor may choose to include the item
+	 * because a particular marketplace requires it or because the vendor feels
+	 * that it enhances the product while another vendor may omit the same item.
+	 *
+	 * @see <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>
+	 */
+	public static final String MAY = "MAY";
 
-    /**
-     * A Linked Data Platform Non-RDF Source (LDP-NR). An LDPR whose state
-     * is not represented in RDF. These are binary or text documents that do not
-     * have useful RDF representations.
-     *
-     * @see <a href="http://www.w3.org/TR/ldp/#terms">LDP Terminology</a>
-     */
-    public static final String NR = "NON-RDF";
+	/**
+	 * A Linked Data Platform Non-RDF Source (LDP-NR). An LDPR whose state
+	 * is not represented in RDF. These are binary or text documents that do not
+	 * have useful RDF representations.
+	 *
+	 * @see <a href="http://www.w3.org/TR/ldp/#terms">LDP Terminology</a>
+	 */
+	public static final String NR = "NON-RDF";
 
-    private static boolean warnings = false;
+	private static boolean warnings = false;
 
-    public static boolean getWarnings() {
-        return warnings;
-    }
+	public static boolean getWarnings() {
+		return warnings;
+	}
 
-    /**
-     * Tests if a Link response header with the expected URI and relation
-     * is present in an HTTP response.
-     *
-     * @param uri          the expected URI
-     * @param linkRelation the expected link relation (rel)
-     * @param response     the HTTP response
-     * @see <a href="http://tools.ietf.org/html/rfc5988">RFC 5988</a>
-     */
-    protected boolean containsLinkHeader(String uri, String linkRelation, Response response) {
-        return containsLinkHeader(uri, linkRelation, response.getHeaders().getList(LINK));
-    }
+	/**
+	 * Tests if a Link response header with the expected URI and relation
+	 * is present in an HTTP response.
+	 *
+	 * @param uri		   the expected URI
+	 * @param linkRelation the expected link relation (rel)
+	 * @param response	   the HTTP response
+	 * @see <a href="http://tools.ietf.org/html/rfc5988">RFC 5988</a>
+	 */
+	protected boolean containsLinkHeader(String uri, String linkRelation, Response response) {
+		return containsLinkHeader(uri, linkRelation, response.getHeaders().getList(LINK));
+	}
 
-    /**
-     * Build a base RestAssured {@link com.jayway.restassured.specification.RequestSpecification}.
-     *
-     * @return RestAssured Request Specification
-     */
-    protected abstract RequestSpecification buildBaseRequestSpecification();
+	/**
+	 * Build a base RestAssured {@link com.jayway.restassured.specification.RequestSpecification}.
+	 *
+	 * @return RestAssured Request Specification
+	 */
+	protected abstract RequestSpecification buildBaseRequestSpecification();
 
-    public Model getAsModel(String uri) {
-        return getResourceAsModel(uri, TEXT_TURTLE);
-    }
+	public Model getAsModel(String uri) {
+		return getResourceAsModel(uri, TEXT_TURTLE);
+	}
 
-    public Model getResourceAsModel(String uri, String mediaType) {
-        return buildBaseRequestSpecification()
-                .header(ACCEPT, mediaType)
-            .expect()
-                .statusCode(isSuccessful())
-            .when()
-                .get(uri).as(Model.class, new RdfObjectMapper(uri));
-    }
+	public Model getResourceAsModel(String uri, String mediaType) {
+		return buildBaseRequestSpecification()
+				.header(ACCEPT, mediaType)
+			.expect()
+				.statusCode(isSuccessful())
+			.when()
+				.get(uri).as(Model.class, new RdfObjectMapper(uri));
+	}
 
-    protected Model postContent() {
-        Model model = ModelFactory.createDefaultModel();
+	protected Model postContent() {
+		Model model = ModelFactory.createDefaultModel();
 
-        if (this.post != null) {
-            InputStream inputStream = getClass().getClassLoader()
-                    .getResourceAsStream(this.post);
+		if (this.post != null) {
+			InputStream inputStream = getClass().getClassLoader()
+					.getResourceAsStream(this.post);
 
-            return model.read(inputStream, "", "TURTLE");
-        }
+			return model.read(inputStream, "", "TURTLE");
+		}
 
-        Resource resource = model.createResource("",
-                model.createResource("http://example.com/ns#Bug"));
-        resource.addProperty(
-                model.createProperty("http://example.com/ns#severity"), "High");
-        resource.addProperty(DC.title, "Another bug to test.");
-        resource.addProperty(DC.description, "Issues that need to be fixed.");
+		Resource resource = model.createResource("",
+				model.createResource("http://example.com/ns#Bug"));
+		resource.addProperty(
+				model.createProperty("http://example.com/ns#severity"), "High");
+		resource.addProperty(DC_11.title, "Another bug to test.");
+		resource.addProperty(DC_11.description, "Issues that need to be fixed.");
 
-        return model;
-    }
+		return model;
+	}
 
-    /**
-     * Check if the header is contained in the headers list
-     * (becase RestAssured only checks the FIRST header)
-     *
-     * @param header  header to look for
-     * @param headers list of headers
-     * @return header is contained
-     */
-    protected boolean containsLinkHeader(Header header, List<Header> headers) {
-        for (Header h : headers) {
-            if (header.equals(h)) {
-                return true;
-            }
-        }
-        return false;
-    }
+	/**
+	 * Check if the header is contained in the headers list
+	 * (becase RestAssured only checks the FIRST header)
+	 *
+	 * @param header  header to look for
+	 * @param headers list of headers
+	 * @return header is contained
+	 */
+	protected boolean containsLinkHeader(Header header, List<Header> headers) {
+		for (Header h : headers) {
+			if (header.equals(h)) {
+				return true;
+			}
+		}
+		return false;
+	}
 
-    /**
-     * Check if the link is contained in the headers list
-     * (becase RestAssured only checks the FIRST header)
-     *
-     * @param link    header to look for
-     * @param headers list of headers
-     * @return link is contained
-     */
-    protected boolean containsLinkHeader(Link link, List<Header> headers) {
-        for (Header header : headers) {
-            for (String s : header.getValue().split(",")) {
-                Link l = new LinkDelegate().fromString(s);
-                if (link.equals(l)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
+	/**
+	 * Check if the link is contained in the headers list
+	 * (becase RestAssured only checks the FIRST header)
+	 *
+	 * @param link	  header to look for
+	 * @param headers list of headers
+	 * @return link is contained
+	 */
+	protected boolean containsLinkHeader(Link link, List<Header> headers) {
+		for (Header header : headers) {
+			for (String s : header.getValue().split(",")) {
+				Link l = new LinkDelegate().fromString(s);
+				if (link.equals(l)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 
-    /**
-     * Check if the link is contained in the headers list
-     * (becase RestAssured only checks the FIRST header)
-     *
-     * @param uri     link uri
-     * @param rel     link rel
-     * @param headers list of headers
-     * @return link is contained
-     */
-    protected boolean containsLinkHeader(String uri, String rel, List<Header> headers) {
-        return containsLinkHeader(Link.fromUri(uri).rel(rel).build(), headers);
-    }
+	/**
+	 * Check if the link is contained in the headers list
+	 * (becase RestAssured only checks the FIRST header)
+	 *
+	 * @param uri	  link uri
+	 * @param rel	  link rel
+	 * @param headers list of headers
+	 * @return link is contained
+	 */
+	protected boolean containsLinkHeader(String uri, String rel, List<Header> headers) {
+		return containsLinkHeader(Link.fromUri(uri).rel(rel).build(), headers);
+	}
 
-    protected String getFirstLinkForRelation(String rel, List<Header> headers) {
-        for (Header header : headers) {
-            for (String s : header.getValue().split(",")) {
-                Link l = new LinkDelegate().fromString(s);
-                if (rel.equals(l.getRel())) {
-                    return l.getUri().toString();
-                }
-            }
-        }
-        return null;
-    }
-    
-    /**
-     * Checks the response for a
-     * <code>Preference-Applied: return=representation</code> response header.
-     * 
-     * @param response
-     *            the HTTP response
-     * @return true if and only if the response contains the expected
-     *         <code>Preference-Applied</code> header
-     */
-    protected boolean isPreferenceApplied(Response response) {
-       List<Header> preferenceAppliedHeaders = response.getHeaders().getList(PREFERNCE_APPLIED); 
-       for (Header h : preferenceAppliedHeaders) {
-            // Handle optional whitespace, quoted preference token values, and
-            // other tokens in the Preference-Applied response header.
-           if (h.getValue().matches("(^|[ ;])return *= *\"?representation\"?($|[ ;])")) {
-               return true;
-           }
-       }
- 
-       return false;
-    }
- 
-    public static String include(String... preferences) {
-        return ldpPreference(PREFERENCE_INCLUDE, preferences);
-    }
-    
-    public static String omit(String... preferences) {
-       return ldpPreference(PREFERENCE_OMIT, preferences); 
-    }
- 
-    private static String ldpPreference(String name, String... values) {
-        return "return=representation; " + name + "=\"" + StringUtils.join(values, " ") + "\"";
-    }
+	protected String getFirstLinkForRelation(String rel, List<Header> headers) {
+		for (Header header : headers) {
+			for (String s : header.getValue().split(",")) {
+				Link l = new LinkDelegate().fromString(s);
+				if (rel.equals(l.getRel())) {
+					return l.getUri().toString();
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Checks the response for a
+	 * <code>Preference-Applied: return=representation</code> response header.
+	 *
+	 * @param response
+	 *			  the HTTP response
+	 * @return true if and only if the response contains the expected
+	 *		   <code>Preference-Applied</code> header
+	 */
+	protected boolean isPreferenceApplied(Response response) {
+	   List<Header> preferenceAppliedHeaders = response.getHeaders().getList(PREFERNCE_APPLIED);
+	   for (Header h : preferenceAppliedHeaders) {
+			// Handle optional whitespace, quoted preference token values, and
+			// other tokens in the Preference-Applied response header.
+		   if (h.getValue().matches("(^|[ ;])return *= *\"?representation\"?($|[ ;])")) {
+			   return true;
+		   }
+	   }
+
+	   return false;
+	}
+
+	public static String include(String... preferences) {
+		return ldpPreference(PREFERENCE_INCLUDE, preferences);
+	}
+
+	public static String omit(String... preferences) {
+	   return ldpPreference(PREFERENCE_OMIT, preferences);
+	}
+
+	private static String ldpPreference(String name, String... values) {
+		return "return=representation; " + name + "=\"" + StringUtils.join(values, " ") + "\"";
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
@@ -19,51 +19,52 @@ import java.io.IOException;
  */
 public class MemberResourceTest extends RdfSourceTest {
 
-    private String container;
-    private String memberResource;
+	private String container;
+	private String memberResource;
 
-    @Parameters({"memberResource", "directContainer", "indirectContainer", "basicContainer", "post", "auth"})
-    public MemberResourceTest(@Optional String memberResource, @Optional String directContainer, 
-        @Optional String indirectContainer, @Optional String basicContainer,
-        @Optional String post, @Optional String auth) throws IOException {
-        super(auth);
-        // If resource is defined, use that. Otherwise, fall back to creating one from one of the containers.
-        if (memberResource != null) {
-            this.memberResource = memberResource;
-        } else if (directContainer != null) {
-            this.container = directContainer;
-        } else if (indirectContainer != null) {
-            this.container = indirectContainer;
-        } else if (basicContainer != null) {
-            this.container = basicContainer;
-        } else {
-            throw new SkipException("No memberResource or container parameters defined in testng.xml");
-        }
-        
-        this.post = post;
+	@Parameters({"memberResource", "directContainer", "indirectContainer", "basicContainer", "post", "auth"})
+	public MemberResourceTest(@Optional String memberResource, @Optional String directContainer,
+		@Optional String indirectContainer, @Optional String basicContainer,
+		@Optional String post, @Optional String auth) throws IOException {
+		super(auth);
+		// If resource is defined, use that. Otherwise, fall back to creating one from one of the containers.
+		if (memberResource != null) {
+			this.memberResource = memberResource;
+		} else if (directContainer != null) {
+			this.container = directContainer;
+		} else if (indirectContainer != null) {
+			this.container = indirectContainer;
+		} else if (basicContainer != null) {
+			this.container = basicContainer;
+		} else {
+			throw new SkipException("No memberResource or container parameters defined in testng.xml");
+		}
 
-        if (this.memberResource == null) {
-            Model model = postContent();
+		this.post = post;
 
-            Response postResponse = buildBaseRequestSpecification()
-                    .contentType(TEXT_TURTLE).body(model, new RdfObjectMapper())
-                            .expect().statusCode(HttpStatus.SC_CREATED).header(LOCATION, notNullValue())
-                            .when().post(this.container);
+		if (this.memberResource == null) {
+			Model model = postContent();
 
-            this.memberResource = postResponse.getHeader(LOCATION);
-        }
-    }
+			Response postResponse = buildBaseRequestSpecification()
+					.contentType(TEXT_TURTLE).body(model, new RdfObjectMapper())
+							.expect().statusCode(HttpStatus.SC_CREATED).header(LOCATION, notNullValue())
+							.when().post(this.container);
 
+			this.memberResource = postResponse.getHeader(LOCATION);
+		}
+	}
+
+	@Override
     protected String getResourceUri() {
-        return memberResource;
-    }
+		return memberResource;
+	}
 
-    @AfterClass(alwaysRun = true)
-    public void deleteTestResource() {
-        // If container isn't null, we created the resource ourselves. To clean up, delete the resource.
-        if (container != null) {
-            buildBaseRequestSpecification().delete(memberResource);
-        }
-    }
+	@AfterClass(alwaysRun = true)
+	public void deleteTestResource() {
+		// If container isn't null, we created the resource ourselves. To clean up, delete the resource.
+		if (container != null) {
+			buildBaseRequestSpecification().delete(memberResource);
+		}
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
@@ -36,367 +36,367 @@ import com.jayway.restassured.response.Response;
  */
 public class NonRDFSourceTest extends CommonResourceTest {
 
-    private final String container;
-    private final URI containerType;
-    /** Resource for CommonResourceTest */
-    private final String nonRdfSource;
+	private final String container;
+	private final URI containerType;
+	/** Resource for CommonResourceTest */
+	private final String nonRdfSource;
 
-    @Parameters({ "basicContainer", "directContainer", "indirectContainer", "auth"})
-    public NonRDFSourceTest(@Optional String basicContainer, @Optional String directContainer, @Optional String indirectContainer, @Optional String auth) throws IOException {
-        super(auth);
-        if (StringUtils.isNotBlank(basicContainer)) {
-            container = basicContainer;
-            containerType = LDP.BasicContainer;
-        } else if (StringUtils.isNotBlank(directContainer)) {
-            container = directContainer;
-            containerType = LDP.DirectContainer;
-        } else if (StringUtils.isNotBlank(indirectContainer)) {
-            container = indirectContainer;
-            containerType = LDP.IndirectContainer;
-        } else {
-            throw new SkipException("No root container provided in testng.xml. Skipping LDP Non-RDF Source (LDP-NR) tests.");
-        }
-        
-        final String slug = "test",
-                file = slug + ".png",
-                mimeType = "image/png";
+	@Parameters({ "basicContainer", "directContainer", "indirectContainer", "auth"})
+	public NonRDFSourceTest(@Optional String basicContainer, @Optional String directContainer, @Optional String indirectContainer, @Optional String auth) throws IOException {
+		super(auth);
+		if (StringUtils.isNotBlank(basicContainer)) {
+			container = basicContainer;
+			containerType = LDP.BasicContainer;
+		} else if (StringUtils.isNotBlank(directContainer)) {
+			container = directContainer;
+			containerType = LDP.DirectContainer;
+		} else if (StringUtils.isNotBlank(indirectContainer)) {
+			container = indirectContainer;
+			containerType = LDP.IndirectContainer;
+		} else {
+			throw new SkipException("No root container provided in testng.xml. Skipping LDP Non-RDF Source (LDP-NR) tests.");
+		}
+		
+		final String slug = "test",
+				file = slug + ".png",
+				mimeType = "image/png";
 
-        // Create a resource to use for CommonResourceTest.
-        Response response = postNonRDFSource(slug, file, mimeType);
-        nonRdfSource = response.getHeader(LOCATION);
-    }
+		// Create a resource to use for CommonResourceTest.
+		Response response = postNonRDFSource(slug, file, mimeType);
+		nonRdfSource = response.getHeader(LOCATION);
+	}
 
-    @AfterClass(alwaysRun = true)
-    public void deleteTestResource() {
-        buildBaseRequestSpecification().delete(nonRdfSource);
-    }
+	@AfterClass(alwaysRun = true)
+	public void deleteTestResource() {
+		buildBaseRequestSpecification().delete(nonRdfSource);
+	}
 
-    @Override
-    protected String getResourceUri() {
-        return nonRdfSource;
-    }
+	@Override
+	protected String getResourceUri() {
+		return nonRdfSource;
+	}
 
-    @Test(
-            groups = {MAY, NR},
-            description = "LDP servers may accept an HTTP POST of non-RDF " +
-                    "representations (LDP-NRs) for creation of any kind of " +
-                    "resource, for example binary resources.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbins",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPostNonRDFSource() throws IOException {
-        // Test constants
-        final String slug = "test",
-                file = slug + ".png",
-                mimeType = "image/png";
+	@Test(
+			groups = {MAY, NR},
+			description = "LDP servers may accept an HTTP POST of non-RDF " +
+					"representations (LDP-NRs) for creation of any kind of " +
+					"resource, for example binary resources.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbins",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPostNonRDFSource() throws IOException {
+		// Test constants
+		final String slug = "test",
+				file = slug + ".png",
+				mimeType = "image/png";
 
-        // Make sure we can post binary resources
-        Response response = postNonRDFSource(slug, file, mimeType);
-        List<Header> links = response.headers().getList("Link");
-        Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
-        buildBaseRequestSpecification().delete(response.getHeader(LOCATION));
-    }
+		// Make sure we can post binary resources
+		Response response = postNonRDFSource(slug, file, mimeType);
+		List<Header> links = response.headers().getList("Link");
+		Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
+		buildBaseRequestSpecification().delete(response.getHeader(LOCATION));
+	}
 
-    @Test(
-            groups = {MAY, NR},
-            description = "LDP servers may accept an HTTP POST of non-RDF " +
-                    "representations (LDP-NRs) for creation of any kind of " +
-                    "resource, for example binary resources.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbins",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testPostResourceAndGetFromContainer() throws IOException {
-        // Test constants
-        final String slug = "test",
-                file = slug + ".png",
-                mimeType = "image/png";
+	@Test(
+			groups = {MAY, NR},
+			description = "LDP servers may accept an HTTP POST of non-RDF " +
+					"representations (LDP-NRs) for creation of any kind of " +
+					"resource, for example binary resources.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbins",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testPostResourceAndGetFromContainer() throws IOException {
+		// Test constants
+		final String slug = "test",
+				file = slug + ".png",
+				mimeType = "image/png";
 
-        // Make sure we can post binary resources
-        Response response = postNonRDFSource(slug, file, mimeType);
-        List<Header> links = response.headers().getList("Link");
-        Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
+		// Make sure we can post binary resources
+		Response response = postNonRDFSource(slug, file, mimeType);
+		List<Header> links = response.headers().getList("Link");
+		Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
 
-        // Check the container contains the new resource
-        Model model = buildBaseRequestSpecification()
-                .header(ACCEPT, TEXT_TURTLE)
-            .expect()
-                .statusCode(HttpStatus.SC_OK)
-                .contentType(TEXT_TURTLE)
-            .get(container)
-                .body().as(Model.class, new RdfObjectMapper(container));
-        assertTrue(model.contains(model.createResource(container), model.createProperty(LDP.contains.stringValue()), model.createResource(response.getHeader(LOCATION))));
+		// Check the container contains the new resource
+		Model model = buildBaseRequestSpecification()
+				.header(ACCEPT, TEXT_TURTLE)
+			.expect()
+				.statusCode(HttpStatus.SC_OK)
+				.contentType(TEXT_TURTLE)
+			.get(container)
+				.body().as(Model.class, new RdfObjectMapper(container));
+		assertTrue(model.contains(model.createResource(container), model.createProperty(LDP.contains.stringValue()), model.createResource(response.getHeader(LOCATION))));
 
-        buildBaseRequestSpecification().delete(response.getHeader(LOCATION));
-    }
+		buildBaseRequestSpecification().delete(response.getHeader(LOCATION));
+	}
 
-    @Test(
-            groups = {MAY, NR},
-            description = "LDP servers may host a mixture of LDP-RSs and LDP-NRs. " +
-                    "For example, it is common for LDP servers to need to host binary " +
-                    "or text resources that do not have useful RDF representations.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-binary",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPostResourceGetBinary() throws IOException {
-        // Test constants
-        final String slug = "test",
-                file = slug + ".png",
-                mimeType = "image/png";
+	@Test(
+			groups = {MAY, NR},
+			description = "LDP servers may host a mixture of LDP-RSs and LDP-NRs. " +
+					"For example, it is common for LDP servers to need to host binary " +
+					"or text resources that do not have useful RDF representations.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-binary",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPostResourceGetBinary() throws IOException {
+		// Test constants
+		final String slug = "test",
+				file = slug + ".png",
+				mimeType = "image/png";
 
-        // Make sure we can post binary resources
-        Response response = postNonRDFSource(slug, file, mimeType);
-        List<Header> links = response.headers().getList("Link");
-        Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
+		// Make sure we can post binary resources
+		Response response = postNonRDFSource(slug, file, mimeType);
+		List<Header> links = response.headers().getList("Link");
+		Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
 
-        // And then check we get the binary back
-        final String expectedMD5 = HashUtils.md5sum(NonRDFSourceTest.class.getResourceAsStream("/" + file));
-        final byte[] binary = buildBaseRequestSpecification()
-                .header(ACCEPT, mimeType)
-            .expect()
-                .statusCode(HttpStatus.SC_OK)
-                .contentType(mimeType)
-                .header(ETAG, HeaderMatchers.isValidEntityTag())
-            .when()
-                .get(response.getHeader(LOCATION))
-                .body().asByteArray();
-        assertEquals(expectedMD5, HashUtils.md5sum(binary), "md5sum");
+		// And then check we get the binary back
+		final String expectedMD5 = HashUtils.md5sum(NonRDFSourceTest.class.getResourceAsStream("/" + file));
+		final byte[] binary = buildBaseRequestSpecification()
+				.header(ACCEPT, mimeType)
+			.expect()
+				.statusCode(HttpStatus.SC_OK)
+				.contentType(mimeType)
+				.header(ETAG, HeaderMatchers.isValidEntityTag())
+			.when()
+				.get(response.getHeader(LOCATION))
+				.body().asByteArray();
+		assertEquals(expectedMD5, HashUtils.md5sum(binary), "md5sum");
 
-        buildBaseRequestSpecification().delete(response.getHeader(LOCATION));
-    }
+		buildBaseRequestSpecification().delete(response.getHeader(LOCATION));
+	}
 
-    @Test(
-            groups = {MAY, NR},
-            description = "Each LDP Non-RDF Source must also be a conforming LDP Resource. " +
-                    "LDP Non-RDF Sources may not be able to fully express their state using RDF.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpnr-are-ldpr",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPostResourceGetMetadataAndBinary() throws IOException {
-        // Test constants
-        final String slug = "test",
-                file = slug + ".png",
-                mimeType = "image/png";
+	@Test(
+			groups = {MAY, NR},
+			description = "Each LDP Non-RDF Source must also be a conforming LDP Resource. " +
+					"LDP Non-RDF Sources may not be able to fully express their state using RDF.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpnr-are-ldpr",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPostResourceGetMetadataAndBinary() throws IOException {
+		// Test constants
+		final String slug = "test",
+				file = slug + ".png",
+				mimeType = "image/png";
 
-        // Make sure we can post binary resources
-        Response response = postNonRDFSource(slug, file, mimeType);
+		// Make sure we can post binary resources
+		Response response = postNonRDFSource(slug, file, mimeType);
 
-        String location = response.getHeader(LOCATION);
-        List<Header> links = response.getHeaders().getList(LINK);
-        String describedBy = getFirstLinkForRelation("describedby", links);
-        Assert.assertNotNull(describedBy, "Expected Link response header with relation 'describedby'");
-        Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
+		String location = response.getHeader(LOCATION);
+		List<Header> links = response.getHeaders().getList(LINK);
+		String describedBy = getFirstLinkForRelation("describedby", links);
+		Assert.assertNotNull(describedBy, "Expected Link response header with relation 'describedby'");
+		Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
 
-        // And then check we get the metadata of back
-        buildBaseRequestSpecification()
-                .header(ACCEPT, TEXT_TURTLE)
-            .expect()
-                .statusCode(HttpStatus.SC_OK)
-                .contentType(TEXT_TURTLE)
-                .header(ETAG, HeaderMatchers.isValidEntityTag())
-            .when()
-                .get(describedBy)
-                .as(Model.class, new RdfObjectMapper(describedBy));
+		// And then check we get the metadata of back
+		buildBaseRequestSpecification()
+				.header(ACCEPT, TEXT_TURTLE)
+			.expect()
+				.statusCode(HttpStatus.SC_OK)
+				.contentType(TEXT_TURTLE)
+				.header(ETAG, HeaderMatchers.isValidEntityTag())
+			.when()
+				.get(describedBy)
+				.as(Model.class, new RdfObjectMapper(describedBy));
 
-        // And the binary too
-        final String expectedMD5 = HashUtils.md5sum(NonRDFSourceTest.class.getResourceAsStream("/" + file));
-        final byte[] binary = buildBaseRequestSpecification()
-                .header(ACCEPT, mimeType)
-            .expect()
-                .statusCode(HttpStatus.SC_OK)
-                .contentType(mimeType)
-                .header(ETAG, HeaderMatchers.isValidEntityTag())
-            .when()
-                .get(location)
-                .body().asByteArray();
-        assertEquals(expectedMD5, HashUtils.md5sum(binary), "md5sum");
+		// And the binary too
+		final String expectedMD5 = HashUtils.md5sum(NonRDFSourceTest.class.getResourceAsStream("/" + file));
+		final byte[] binary = buildBaseRequestSpecification()
+				.header(ACCEPT, mimeType)
+			.expect()
+				.statusCode(HttpStatus.SC_OK)
+				.contentType(mimeType)
+				.header(ETAG, HeaderMatchers.isValidEntityTag())
+			.when()
+				.get(location)
+				.body().asByteArray();
+		assertEquals(expectedMD5, HashUtils.md5sum(binary), "md5sum");
 
-        buildBaseRequestSpecification().delete(location);
-    }
+		buildBaseRequestSpecification().delete(location);
+	}
 
-    @Test(
-            groups = {MAY, NR},
-            description = "LDP servers exposing an LDP Non-RDF Source may advertise this by exposing " +
-                    "a HTTP Link header with a target URI of http://www.w3.org/ns/ldp#NonRDFSource, and " +
-                    "a link relation type of type (that is, rel='type') in responses to requests made to " +
-                    "the LDP-NR's HTTP Request-URI.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpnr-type",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPostResourceAndCheckLink() throws IOException {
-        // Test constants
-        final String slug = "test",
-                file = slug + ".png",
-                mimeType = "image/png";
+	@Test(
+			groups = {MAY, NR},
+			description = "LDP servers exposing an LDP Non-RDF Source may advertise this by exposing " +
+					"a HTTP Link header with a target URI of http://www.w3.org/ns/ldp#NonRDFSource, and " +
+					"a link relation type of type (that is, rel='type') in responses to requests made to " +
+					"the LDP-NR's HTTP Request-URI.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpnr-type",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPostResourceAndCheckLink() throws IOException {
+		// Test constants
+		final String slug = "test",
+				file = slug + ".png",
+				mimeType = "image/png";
 
-        // Make sure we can post binary resources
-        Response response = postNonRDFSource(slug, file, mimeType);
-        List<Header> links = response.headers().getList(LINK);
-        Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
+		// Make sure we can post binary resources
+		Response response = postNonRDFSource(slug, file, mimeType);
+		List<Header> links = response.headers().getList(LINK);
+		Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
 
-        // And then check the link when requesting the LDP-NR
-        List<Header> linksNR = buildBaseRequestSpecification()
-            .expect()
-                .statusCode(isSuccessful())
-                .header(ETAG, HeaderMatchers.isValidEntityTag())
-            .when()
-                .get(response.getHeader(LOCATION))
-                .headers().getList(LINK);
-        Assert.assertTrue(containsLinkHeader(LDP.NonRDFSource.stringValue(), "type", linksNR));
+		// And then check the link when requesting the LDP-NR
+		List<Header> linksNR = buildBaseRequestSpecification()
+			.expect()
+				.statusCode(isSuccessful())
+				.header(ETAG, HeaderMatchers.isValidEntityTag())
+			.when()
+				.get(response.getHeader(LOCATION))
+				.headers().getList(LINK);
+		Assert.assertTrue(containsLinkHeader(LDP.NonRDFSource.stringValue(), "type", linksNR));
 
-        buildBaseRequestSpecification().delete(response.header(LOCATION));
-    }
+		buildBaseRequestSpecification().delete(response.header(LOCATION));
+	}
 
-    @Test(
-            groups = {MAY, NR},
-            description = "Upon successful creation of an LDP-NR (HTTP status code of 201-Created and " +
-                    "URI indicated by Location response header), LDP servers may create an associated " +
-                    "LDP-RS to contain data about the newly created LDP-NR. If a LDP server creates " +
-                    "this associated LDP-RS it must indicate its location on the HTTP response using " +
-                    "the HTTP Link response header with link relation describedby and href to be the " +
-                    "URI of the associated LDP-RS resource.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbinlinkmetahdr",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPostResourceAndCheckAssociatedResource() throws IOException {
-        // Test constants
-        final String slug = "test",
-                file = slug + ".png",
-                mimeType = "image/png";
+	@Test(
+			groups = {MAY, NR},
+			description = "Upon successful creation of an LDP-NR (HTTP status code of 201-Created and " +
+					"URI indicated by Location response header), LDP servers may create an associated " +
+					"LDP-RS to contain data about the newly created LDP-NR. If a LDP server creates " +
+					"this associated LDP-RS it must indicate its location on the HTTP response using " +
+					"the HTTP Link response header with link relation describedby and href to be the " +
+					"URI of the associated LDP-RS resource.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-post-createbinlinkmetahdr",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPostResourceAndCheckAssociatedResource() throws IOException {
+		// Test constants
+		final String slug = "test",
+				file = slug + ".png",
+				mimeType = "image/png";
 
-        // Make sure we can post binary resources
-        Response response = postNonRDFSource(slug, file, mimeType);
-        List<Header> links = response.headers().getList(LINK);
-        String describedBy = getFirstLinkForRelation("describedby", links);
-        Assert.assertNotNull(describedBy, "Expected Link response header with relation 'describedby'");
-        Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
-        String location = response.getHeader(LOCATION);
+		// Make sure we can post binary resources
+		Response response = postNonRDFSource(slug, file, mimeType);
+		List<Header> links = response.headers().getList(LINK);
+		String describedBy = getFirstLinkForRelation("describedby", links);
+		Assert.assertNotNull(describedBy, "Expected Link response header with relation 'describedby'");
+		Assert.assertTrue(containsLinkHeader(containerType.stringValue(), "type", links));
+		String location = response.getHeader(LOCATION);
 
-        // Check the link when requesting the LDP-NS
-        List<Header> linksNR = buildBaseRequestSpecification()
-            .expect()
-                .statusCode(isSuccessful())
-                .header(ETAG, HeaderMatchers.headerPresent())
-            .when()
-                .get(location)
-                .headers().getList("Link");
-        Assert.assertTrue(containsLinkHeader(describedBy, "describedby", linksNR));
+		// Check the link when requesting the LDP-NS
+		List<Header> linksNR = buildBaseRequestSpecification()
+			.expect()
+				.statusCode(isSuccessful())
+				.header(ETAG, HeaderMatchers.headerPresent())
+			.when()
+				.get(location)
+				.headers().getList("Link");
+		Assert.assertTrue(containsLinkHeader(describedBy, "describedby", linksNR));
 
-        // And then check the associated LDP-RS is actually there
-        buildBaseRequestSpecification()
-                .header(ACCEPT, TEXT_TURTLE)
-            .expect()
-                .statusCode(isSuccessful())
-                .contentType(TEXT_TURTLE)
-                .header(ETAG, HeaderMatchers.isValidEntityTag())
-            .when()
-                .get(describedBy);
+		// And then check the associated LDP-RS is actually there
+		buildBaseRequestSpecification()
+				.header(ACCEPT, TEXT_TURTLE)
+			.expect()
+				.statusCode(isSuccessful())
+				.contentType(TEXT_TURTLE)
+				.header(ETAG, HeaderMatchers.isValidEntityTag())
+			.when()
+				.get(describedBy);
 
-        buildBaseRequestSpecification().delete(location);
-    }
+		buildBaseRequestSpecification().delete(location);
+	}
 
-    @Test(
-            groups = {MUST, NR},
-            description = "When a contained LDPR is deleted, and the LDPC server created an"+
-                    "associated LDP-RS (see the LDPC POST section), the LDPC server must also"+
-                    "delete the associated LDP-RS it created.",
-            dependsOnMethods = "testPostResourceAndCheckAssociatedResource")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-del-contremovescontres",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testDeleteNonRDFSourceDeletesAssociatedResource() throws IOException {
-        // Test constants
-        final String slug = "test",
-                file = slug + ".png",
-                mimeType = "image/png";
+	@Test(
+			groups = {MUST, NR},
+			description = "When a contained LDPR is deleted, and the LDPC server created an"+
+					"associated LDP-RS (see the LDPC POST section), the LDPC server must also"+
+					"delete the associated LDP-RS it created.",
+			dependsOnMethods = "testPostResourceAndCheckAssociatedResource")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-del-contremovescontres",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testDeleteNonRDFSourceDeletesAssociatedResource() throws IOException {
+		// Test constants
+		final String slug = "test",
+				file = slug + ".png",
+				mimeType = "image/png";
 
-        // Make sure we can post binary resources
-        Response postResponse = postNonRDFSource(slug, file, mimeType);
-        List<Header> links = postResponse.headers().getList(LINK);
-        String describedBy = getFirstLinkForRelation("describedby", links);
-        Assert.assertNotNull(describedBy, "Expected Link response header with relation 'describedby'");
-        String location = postResponse.getHeader(LOCATION);
+		// Make sure we can post binary resources
+		Response postResponse = postNonRDFSource(slug, file, mimeType);
+		List<Header> links = postResponse.headers().getList(LINK);
+		String describedBy = getFirstLinkForRelation("describedby", links);
+		Assert.assertNotNull(describedBy, "Expected Link response header with relation 'describedby'");
+		String location = postResponse.getHeader(LOCATION);
 
-        // And then check the associated LDP-RS is actually there
-        buildBaseRequestSpecification()
-                .header(ACCEPT, TEXT_TURTLE)
-            .expect()
-                .statusCode(isSuccessful())
-                .contentType(TEXT_TURTLE)
-            .when()
-                .get(describedBy);
+		// And then check the associated LDP-RS is actually there
+		buildBaseRequestSpecification()
+				.header(ACCEPT, TEXT_TURTLE)
+			.expect()
+				.statusCode(isSuccessful())
+				.contentType(TEXT_TURTLE)
+			.when()
+				.get(describedBy);
 
-        // Delete the LDP-NR.
-        buildBaseRequestSpecification()
-            .expect()
-                .statusCode(isSuccessful())
-            .when()
-                .delete(location);
+		// Delete the LDP-NR.
+		buildBaseRequestSpecification()
+			.expect()
+				.statusCode(isSuccessful())
+			.when()
+				.delete(location);
 
-        // Check that the associated LDP-RS is also deleted.
-        buildBaseRequestSpecification()
-                .header(ACCEPT, TEXT_TURTLE)
-            .expect()
-                .statusCode(isNotFoundOrGone())
-            .when()
-                .get(describedBy);
-    }
+		// Check that the associated LDP-RS is also deleted.
+		buildBaseRequestSpecification()
+				.header(ACCEPT, TEXT_TURTLE)
+			.expect()
+				.statusCode(isNotFoundOrGone())
+			.when()
+				.get(describedBy);
+	}
 
-    protected Response postNonRDFSource(String slug, String file, String mimeType) throws IOException {
-        // Make sure we can post binary resources
-        return buildBaseRequestSpecification()
-                .header(SLUG, slug)
-                .body(IOUtils.toByteArray(getClass().getResourceAsStream("/" + file)))
-                .contentType(mimeType)
-            .expect()
-                .statusCode(HttpStatus.SC_CREATED)
-                .header(LOCATION, HeaderMatchers.headerPresent())
-            .when()
-                .post(container);
-    }
+	protected Response postNonRDFSource(String slug, String file, String mimeType) throws IOException {
+		// Make sure we can post binary resources
+		return buildBaseRequestSpecification()
+				.header(SLUG, slug)
+				.body(IOUtils.toByteArray(getClass().getResourceAsStream("/" + file)))
+				.contentType(mimeType)
+			.expect()
+				.statusCode(HttpStatus.SC_CREATED)
+				.header(LOCATION, HeaderMatchers.headerPresent())
+			.when()
+				.post(container);
+	}
 
-    @Test(
-            groups = {MUST, NR},
-            description = "When responding to requests whose request-URI is a LDP-NR with an"+
-                    "associated LDP-RS, a LDPC server must provide the same HTTP Link response"+
-                    "header as is required in the create response",
-            dependsOnMethods = "testPostResourceAndCheckAssociatedResource")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-options-linkmetahdr",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testOptionsHasSameLinkHeader() throws IOException {
-        // Test constants
-        final String slug = "test",
-                file = slug + ".png",
-                mimeType = "image/png";
+	@Test(
+			groups = {MUST, NR},
+			description = "When responding to requests whose request-URI is a LDP-NR with an"+
+					"associated LDP-RS, a LDPC server must provide the same HTTP Link response"+
+					"header as is required in the create response",
+			dependsOnMethods = "testPostResourceAndCheckAssociatedResource")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpc-options-linkmetahdr",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testOptionsHasSameLinkHeader() throws IOException {
+		// Test constants
+		final String slug = "test",
+				file = slug + ".png",
+				mimeType = "image/png";
 
-        // Make sure we can post binary resources
-        Response postResponse = postNonRDFSource(slug, file, mimeType);
+		// Make sure we can post binary resources
+		Response postResponse = postNonRDFSource(slug, file, mimeType);
 
-        String location = postResponse.getHeader(LOCATION);
-        List<Header> links = postResponse.getHeaders().getList(LINK);
-        String describedBy = getFirstLinkForRelation("describedby", links);
-        Assert.assertNotNull(describedBy, "Expected Link response header with relation 'describedby' for LDP-NR POST request");
+		String location = postResponse.getHeader(LOCATION);
+		List<Header> links = postResponse.getHeaders().getList(LINK);
+		String describedBy = getFirstLinkForRelation("describedby", links);
+		Assert.assertNotNull(describedBy, "Expected Link response header with relation 'describedby' for LDP-NR POST request");
 
-        // Check the Link headers on an HTTP OPTIONS for the LDP-NR
-        List<Header> linksOPTIONS = buildBaseRequestSpecification()
-            .expect()
-                .statusCode(isSuccessful())
-            .when()
-                .options(location)
-                .getHeaders().getList(LINK);
-        Assert.assertTrue(containsLinkHeader(describedBy, "describedby", linksOPTIONS),
-                "Expected Link response header with relation 'describedby' and URI <"
-                        + describedBy + "> for LDP-NR OPTIONS request");
+		// Check the Link headers on an HTTP OPTIONS for the LDP-NR
+		List<Header> linksOPTIONS = buildBaseRequestSpecification()
+			.expect()
+				.statusCode(isSuccessful())
+			.when()
+				.options(location)
+				.getHeaders().getList(LINK);
+		Assert.assertTrue(containsLinkHeader(describedBy, "describedby", linksOPTIONS),
+				"Expected Link response header with relation 'describedby' and URI <"
+						+ describedBy + "> for LDP-NR OPTIONS request");
 
-        buildBaseRequestSpecification().delete(location);
-    }
+		buildBaseRequestSpecification().delete(location);
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
@@ -7,9 +7,7 @@ import static org.w3.ldp.testsuite.matcher.HttpStatusSuccessMatcher.isSuccessful
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
-import org.apache.marmotta.commons.vocabulary.LDP;
 import org.testng.SkipException;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
@@ -42,419 +40,420 @@ import com.jayway.restassured.response.Response;
  */
 public abstract class RdfSourceTest extends CommonResourceTest {
 
-    @Parameters("auth")
-    public RdfSourceTest(@Optional String auth) throws IOException {
-        super(auth);
-    }
+	@Parameters("auth")
+	public RdfSourceTest(@Optional String auth) throws IOException {
+		super(auth);
+	}
 
+	@Test(
+			groups = {MUST},
+			description = "LDP servers MUST assign the default base-URI "
+					+ "for [RFC3987] relative-URI resolution to be the HTTP "
+					+ "Request-URI when the resource already exists, and to "
+					+ "the URI of the created resource when the request results "
+					+ "in the creation of a new resource.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-defbaseuri",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testRelativeUriResolutionPut() {
+		skipIfMethodNotAllowed(HttpMethod.PUT);
+
+		String resourceUri = getResourceUri();
+		Response response = buildBaseRequestSpecification()
+				.header(ACCEPT, TEXT_TURTLE)
+			.expect()
+				.statusCode(isSuccessful())
+				.header(ETAG, isValidEntityTag())
+			.when()
+				.get(resourceUri);
+
+		String eTag = response.getHeader(ETAG);
+		Model model = response.as(Model.class, new RdfObjectMapper(resourceUri));
+
+		// Make sure the resource is specified using a relative URI
+		ResourceUtils.renameResource(model.getResource(resourceUri), "");
+
+		// Update a property
+		updateResource(model.getResource(""));
+
+		// Put the resource back using relative URIs.
+		Response put = buildBaseRequestSpecification()
+				.contentType(TEXT_TURTLE).header(IF_MATCH, eTag)
+				.body(model, new RdfObjectMapper("")) // relative URI
+				.when().put(resourceUri);
+		if (!isSuccessful().matches(put.getStatusCode())) {
+		   throw new SkipException("Cannot verify relative URI resolution because the PUT request failed. Skipping test.");
+		}
+
+		// Get the resource again to verify its content.
+		model = buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
+				.expect().statusCode(isSuccessful())
+				.when().get(resourceUri).as(Model.class, new RdfObjectMapper(resourceUri));
+
+		// Verify the change.
+		verifyUpdatedResource(model.getResource(resourceUri));
+	}
+
+	@Test(
+			groups = {MUST},
+			description = "If a HTTP PUT is accepted on an existing resource, "
+					+ "LDP servers MUST replace the entire persistent state of "
+					+ "the identified resource with the entity representation "
+					+ "in the body of the request.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-replaceall",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testPutReplacesResource() {
+		skipIfMethodNotAllowed(HttpMethod.PUT);
+
+		if (restrictionsOnContent()) {
+			throw new SkipException("Skipping test because there are restrictions on PUT content for this resource");
+		}
+
+		// TODO: Is there a better way to test this requirement?
+		String resourceUri = getResourceUri();
+		Response response = buildBaseRequestSpecification()
+						.header(ACCEPT, TEXT_TURTLE)
+				.expect()
+						.statusCode(isSuccessful())
+						.header(ETAG, isValidEntityTag())
+				.when()
+						.get(resourceUri);
+
+		String eTag = response.getHeader(ETAG);
+		Model originalModel = response.as(Model.class, new RdfObjectMapper(resourceUri));
+
+		// Replace the resource with something different.
+		Model differentContent = ModelFactory.createDefaultModel();
+		final String UPDATED_TITLE = "This resources content has been replaced";
+		differentContent.add(differentContent.getResource(resourceUri),
+				DCTerms.title, UPDATED_TITLE);
+
+		buildBaseRequestSpecification()
+				.given().contentType(TEXT_TURTLE).header(IF_MATCH, eTag)
+				.body(differentContent, new RdfObjectMapper(resourceUri)) // relative URI
+				.expect().statusCode(isSuccessful())
+				.when().put(resourceUri);
+
+		// Get the resource again to see what's there.
+		response = buildBaseRequestSpecification()
+				.header(ACCEPT, TEXT_TURTLE)
+			.expect()
+				.statusCode(isSuccessful())
+				.header(ETAG, isValidEntityTag())
+			.when()
+				.get(resourceUri);
+		eTag = response.getHeader(ETAG);
+		Model updatedModel = response.as(Model.class, new RdfObjectMapper(resourceUri));
+
+		// Validate the updated resource content. The LDP server is allowed to add in
+		// some triples (for instance, dcterms:lastModified), so we can't just compare
+		// that it's exactly what we posted. Let's make sure not all of the triples
+		// from the original resource are there since we've completely replaced it,
+		// however. Also check that the title is as expected.
+		Resource updatedResource = updatedModel.getResource(resourceUri);
+		assertTrue(updatedResource.hasProperty(DCTerms.title, UPDATED_TITLE), "Expected updated resource to have title: " + UPDATED_TITLE);
+		boolean hasDifferentProperties = false;
+		Resource originalResource = originalModel.getResource(resourceUri);
+		StmtIterator iter = originalResource.listProperties();
+		while (iter.hasNext()) {
+			Statement s = iter.next();
+			if (!updatedResource.hasProperty(s.getPredicate())) {
+				hasDifferentProperties = true;
+			}
+		}
+		assertTrue(hasDifferentProperties, "The updated resource has the same properties as the original. Was it really replaced?");
+
+		// Replace the resource with its original content to clean up.
+		buildBaseRequestSpecification()
+				.contentType(TEXT_TURTLE).header(IF_MATCH, eTag)
+				.body(originalModel, new RdfObjectMapper(resourceUri)) // relative URI
+				.expect().statusCode(isSuccessful())
+				.when().put(resourceUri);
+	}
+
+	@Override
     @Test(
-            groups = {MUST},
-            description = "LDP servers MUST assign the default base-URI "
-                    + "for [RFC3987] relative-URI resolution to be the HTTP "
-                    + "Request-URI when the resource already exists, and to "
-                    + "the URI of the created resource when the request results "
-                    + "in the creation of a new resource.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-defbaseuri",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testRelativeUriResolutionPut() {
-        skipIfMethodNotAllowed(HttpMethod.PUT);
+			groups = {MUST},
+			description = "LDP servers MUST provide an RDF representation "
+					+ "for LDP-RSs. The HTTP Request-URI of the LDP-RS is "
+					+ "typically the subject of most triples in the response.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-rdf",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testGetResource() {
+		// Make sure we can get the resource itself and the response is
+		// valid RDF. Turtle is a required media type, so this request
+		// should succeed for all LDP-RS.
+		buildBaseRequestSpecification()
+				.header(ACCEPT, TEXT_TURTLE)
+				.expect().statusCode(HttpStatus.SC_OK).contentType(TEXT_TURTLE)
+				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
+	}
 
-        String resourceUri = getResourceUri();
-        Response response = buildBaseRequestSpecification()
-                .header(ACCEPT, TEXT_TURTLE)
-            .expect()
-                .statusCode(isSuccessful())
-                .header(ETAG, isValidEntityTag())
-            .when()
-                .get(resourceUri);
+	@Test(
+			groups = {SHOULD},
+			description = "LDP-RSs representations SHOULD have at least one "
+					+ "rdf:type set explicitly. This makes the representations"
+					+ " much more useful to client applications that don’t "
+					+ "support inferencing.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-atleast1rdftype",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testContainsRdfType() {
+		Model containerModel = getAsModel(getResourceUri());
+		Resource r = containerModel.getResource(getResourceUri());
+		assertTrue(r.hasProperty(RDF.type), "LDP-RS representation has no explicit rdf:type");
+	}
 
-        String eTag = response.getHeader(ETAG);
-        Model model = response.as(Model.class, new RdfObjectMapper(resourceUri));
- 
-        // Make sure the resource is specified using a relative URI
-        ResourceUtils.renameResource(model.getResource(resourceUri), "");
+	@Test(
+			groups = {SHOULD},
+			description = "LDP-RSs SHOULD reuse existing vocabularies instead of "
+					+ "creating their own duplicate vocabulary terms. In addition "
+					+ "to this general rule, some specific cases are covered by "
+					+ "other conformance rules.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-reusevocab",
+			testMethod = METHOD.MANUAL,
+			approval = STATUS.WG_APPROVED)
+	public void testReUseVocabularies() {
+		throw new SkipNotTestableException();
+	}
 
-        // Update a property
-        updateResource(model.getResource(""));
-        
-        // Put the resource back using relative URIs.
-        Response put = buildBaseRequestSpecification()
-                .contentType(TEXT_TURTLE).header(IF_MATCH, eTag)
-                .body(model, new RdfObjectMapper("")) // relative URI
-                .when().put(resourceUri);
-        if (!isSuccessful().matches(put.getStatusCode())) {
-           throw new SkipException("Cannot verify relative URI resolution because the PUT request failed. Skipping test."); 
-        }
+	@Test(
+			groups = {SHOULD},
+			description = "LDP-RSs predicates SHOULD use standard vocabularies such "
+					+ "as Dublin Core [DC-TERMS], RDF [rdf11-concepts] and RDF "
+					+ "Schema [rdf-schema], whenever possible.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-reusevocabsuchas",
+			testMethod = METHOD.MANUAL,
+			approval = STATUS.WG_APPROVED)
+	public void testUseStandardVocabularies() throws URISyntaxException {
+		// TODO: Consider ideas for testUseStandardVocabularies (see comment)
+		/* Possible ideas:
+		   fetch resource, look for known vocabulary term
+		   URIs.  Also can look at total number of terms and have a threshold
+		   of differences, say 100 terms and < 5 standard predicates would be odd.
+		   Also could look for similar/like short predicate short names or even
+		   look for owl:sameAs.
+		*/
+		throw new SkipNotTestableException();
+	}
 
-        // Get the resource again to verify its content.
-        model = buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
-                .expect().statusCode(isSuccessful())
-                .when().get(resourceUri).as(Model.class, new RdfObjectMapper(resourceUri));
+	@Test(
+			groups = {MUST},
+			description = "In the absence of special knowledge of the application "
+					+ "or domain, LDP clients MUST assume that any LDP-RS can "
+					+ "have multiple values for rdf:type.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldp-cli-multitype",
+			testMethod = METHOD.CLIENT_ONLY,
+			approval = STATUS.WG_APPROVED)
+	public void testAllowMultipleRdfTypes() {
+		throw new SkipClientTestException();
+	}
 
-        // Verify the change.
-        verifyUpdatedResource(model.getResource(resourceUri));
-    }
-    
-    @Test(
-            groups = {MUST},
-            description = "If a HTTP PUT is accepted on an existing resource, "
-                    + "LDP servers MUST replace the entire persistent state of "
-                    + "the identified resource with the entity representation "
-                    + "in the body of the request.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-put-replaceall",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testPutReplacesResource() {
-        skipIfMethodNotAllowed(HttpMethod.PUT);
+	@Test(
+			groups = {MUST},
+			description = "In the absence of special knowledge of the "
+					+ "application or domain, LDP clients MUST assume "
+					+ "that the rdf:type values of a given LDP-RS can "
+					+ "change over time.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-cli-typeschange",
+			testMethod = METHOD.CLIENT_ONLY,
+			approval = STATUS.WG_APPROVED)
+	public void testChangeRdfTypeValue() {
+		throw new SkipClientTestException();
+	}
 
-        if (restrictionsOnContent()) {
-            throw new SkipException("Skipping test because there are restrictions on PUT content for this resource");
-        }
+	@Test(
+			groups = {SHOULD},
+			description = "LDP clients SHOULD always assume that the set "
+					+ "of predicates for a LDP-RS of a particular type at "
+					+ "an arbitrary server is open, in the sense that different "
+					+ "resources of the same type may not all have the same set "
+					+ "of predicates in their triples, and the set of predicates "
+					+ "that are used in the state of any one LDP-RS is not limited "
+					+ "to any pre-defined set.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-cli-openpreds",
+			testMethod = METHOD.CLIENT_ONLY,
+			approval = STATUS.WG_APPROVED)
+	public void testServerOpen() {
+		throw new SkipClientTestException();
+	}
 
-        // TODO: Is there a better way to test this requirement?
-        String resourceUri = getResourceUri();
-        Response response = buildBaseRequestSpecification()
-                        .header(ACCEPT, TEXT_TURTLE)
-                .expect()
-                        .statusCode(isSuccessful())
-                        .header(ETAG, isValidEntityTag())
-                .when()
-                        .get(resourceUri);
+	@Test(
+			groups = {MUST},
+			description = "LDP servers MUST NOT require LDP clients to implement inferencing "
+					+ "in order to recognize the subset of content defined by LDP. Other "
+					+ "specifications built on top of LDP may require clients to implement "
+					+ "inferencing [rdf11-concepts]. The practical implication is that all "
+					+ "content defined by LDP must be explicitly represented, unless noted "
+					+ "otherwise within this document.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-noinferencing",
+			testMethod = METHOD.MANUAL,
+			approval = STATUS.WG_APPROVED)
+	public void testRestrictClientInference() {
+		throw new SkipNotTestableException();
+	}
 
-        String eTag = response.getHeader(ETAG);
-        Model originalModel = response.as(Model.class, new RdfObjectMapper(resourceUri));
+	@Test(
+			groups = {MUST},
+			description = "A LDP client MUST preserve all triples retrieved "
+					+ "from an LDP-RS using HTTP GET that it doesn’t change "
+					+ "whether it understands the predicates or not, when its "
+					+ "intent is to perform an update using HTTP PUT. The use of "
+					+ "HTTP PATCH instead of HTTP PUT for update avoids this "
+					+ "burden for clients [RFC5789]. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-cli-preservetriples",
+			testMethod = METHOD.MANUAL,
+			approval = STATUS.WG_APPROVED)
+	public void testGetResourcePreservesTriples() throws URISyntaxException {
+		throw new SkipNotTestableException();
+	}
 
-        // Replace the resource with something different.
-        Model differentContent = ModelFactory.createDefaultModel();
-        final String UPDATED_TITLE = "This resources content has been replaced";
-        differentContent.add(differentContent.getResource(resourceUri),
-                DCTerms.title, UPDATED_TITLE);
+	@Test(
+			groups = {MUST},
+			description = "LDP clients MUST be capable of processing responses "
+					+ "formed by an LDP server that ignores hints, including "
+					+ "LDP-defined hints.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-cli-hints-ignorable",
+			testMethod = METHOD.MANUAL,
+			approval = STATUS.WG_APPROVED)
+	public void testAllowResponsesFromServer() {
+		throw new SkipNotTestableException();
+	}
 
-        buildBaseRequestSpecification()
-                .given().contentType(TEXT_TURTLE).header(IF_MATCH, eTag)
-                .body(differentContent, new RdfObjectMapper(resourceUri)) // relative URI
-                .expect().statusCode(isSuccessful())
-                .when().put(resourceUri);
+	@Test(
+			groups = {MUST},
+			description = "LDP servers must provide a text/turtle representation "
+					+ "of the requested LDP-RS whenever HTTP content negotiation "
+					+ "does not force another outcome [turtle]. In other words, if "
+					+ "the server receives a GET request whose Request-URI "
+					+ "identifies a LDP-RS, and either text/turtle has the highest "
+					+ "relative quality factor (q= value) in the Accept request "
+					+ "header or that header is absent, then an LDP server has to "
+					+ "respond with Turtle.")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-get-turtle",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_APPROVED)
+	public void testGetResourceAcceptTurtle() {
+		// Accept: text/turtle
+		buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
+				.expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
+				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
 
-        // Get the resource again to see what's there.
-        response = buildBaseRequestSpecification()
-                .header(ACCEPT, TEXT_TURTLE)
-            .expect()
-                .statusCode(isSuccessful())
-                .header(ETAG, isValidEntityTag())
-            .when()
-                .get(resourceUri);
-        eTag = response.getHeader(ETAG);
-        Model updatedModel = response.as(Model.class, new RdfObjectMapper(resourceUri));
+		// No Accept header
+		buildBaseRequestSpecification()
+				.expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
+				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
 
-        // Validate the updated resource content. The LDP server is allowed to add in
-        // some triples (for instance, dcterms:lastModified), so we can't just compare
-        // that it's exactly what we posted. Let's make sure not all of the triples
-        // from the original resource are there since we've completely replaced it,
-        // however. Also check that the title is as expected.
-        Resource updatedResource = updatedModel.getResource(resourceUri);
-        assertTrue(updatedResource.hasProperty(DCTerms.title, UPDATED_TITLE), "Expected updated resource to have title: " + UPDATED_TITLE);
-        boolean hasDifferentProperties = false;
-        Resource originalResource = originalModel.getResource(resourceUri);
-        StmtIterator iter = originalResource.listProperties();
-        while (iter.hasNext()) {
-            Statement s = iter.next();
-            if (!updatedResource.hasProperty(s.getPredicate())) {
-                hasDifferentProperties = true;
-            }
-        }
-        assertTrue(hasDifferentProperties, "The updated resource has the same properties as the original. Was it really replaced?");
+		// Wildcard
+		buildBaseRequestSpecification().header(ACCEPT, "*/*")
+				.expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
+				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
 
-        // Replace the resource with its original content to clean up.
-        buildBaseRequestSpecification()
-                .contentType(TEXT_TURTLE).header(IF_MATCH, eTag)
-                .body(originalModel, new RdfObjectMapper(resourceUri)) // relative URI
-                .expect().statusCode(isSuccessful())
-                .when().put(resourceUri);
-    }
+		// Accept: text/*
+		buildBaseRequestSpecification().header(ACCEPT, "text/*")
+				.expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
+				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers MUST provide an RDF representation "
-                    + "for LDP-RSs. The HTTP Request-URI of the LDP-RS is "
-                    + "typically the subject of most triples in the response.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-rdf",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testGetResource() {
-        // Make sure we can get the resource itself and the response is
-        // valid RDF. Turtle is a required media type, so this request
-        // should succeed for all LDP-RS.
-        buildBaseRequestSpecification()
-                .header(ACCEPT, TEXT_TURTLE)
-                .expect().statusCode(HttpStatus.SC_OK).contentType(TEXT_TURTLE)
-                .when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
-    }
+		// More complicated Accept header
+		buildBaseRequestSpecification().header(ACCEPT, "text/turtle;q=0.9,application/json;q=0.8")
+				.expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
+				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
+	}
 
-    @Test(
-            groups = {SHOULD},
-            description = "LDP-RSs representations SHOULD have at least one "
-                    + "rdf:type set explicitly. This makes the representations"
-                    + " much more useful to client applications that don’t "
-                    + "support inferencing.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-atleast1rdftype",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testContainsRdfType() {
-        Model containerModel = getAsModel(getResourceUri());
-        Resource r = containerModel.getResource(getResourceUri());
-        assertTrue(r.hasProperty(RDF.type), "LDP-RS representation has no explicit rdf:type");
-    }
+	/**
+	 * This is a client-only test. Server tests are covered by
+	 * {@link CommonContainerTest#testPreferContainmentTriples()} and
+	 * {@link DirectContainerTest#testPreferMembershipTriples()}.
+	 */
+	@Test(
+			enabled = false,
+			groups = {MAY},
+			description = "LDP clients MAY provide LDP-defined hints that allow servers "
+					+ "to optimize the content of responses. section 7.2 Preferences on "
+					+ "the Prefer Request Header defines hints that apply to LDP-RSs. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-cli-can-hint",
+			testMethod = METHOD.CLIENT_ONLY,
+			approval = STATUS.WG_PENDING)
+	public void testClientMayProvideHints() {
+		throw new SkipClientTestException();
+	}
 
-    @Test(
-            groups = {SHOULD},
-            description = "LDP-RSs SHOULD reuse existing vocabularies instead of "
-                    + "creating their own duplicate vocabulary terms. In addition "
-                    + "to this general rule, some specific cases are covered by "
-                    + "other conformance rules.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-reusevocab",
-            testMethod = METHOD.MANUAL,
-            approval = STATUS.WG_APPROVED)
-    public void testReUseVocabularies() {
-        throw new SkipNotTestableException();
-    }
+	@Test(
+			groups = {SHOULD},
+			description = "LDP servers SHOULD offer a application/ld+json representation"
+					+ " of the requested LDP-RS [JSON-LD]. ")
+	@SpecTest(
+			specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-get-jsonld",
+			testMethod = METHOD.AUTOMATED,
+			approval = STATUS.WG_PENDING)
+	public void testJsonLdRepresentation() throws IOException, JsonLdError {
+		Response response = buildBaseRequestSpecification()
+				.header(ACCEPT, "application/ld+json, application/json;q=0.5")
+				.expect()
+				.statusCode(isSuccessful())
+				.contentType(HeaderMatchers.isJsonLdCompatibleContentType())
+				.when()
+				.get(getResourceUri());
 
-    @Test(
-            groups = {SHOULD},
-            description = "LDP-RSs predicates SHOULD use standard vocabularies such "
-                    + "as Dublin Core [DC-TERMS], RDF [rdf11-concepts] and RDF "
-                    + "Schema [rdf-schema], whenever possible.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-reusevocabsuchas",
-            testMethod = METHOD.MANUAL,
-            approval = STATUS.WG_APPROVED)
-    public void testUseStandardVocabularies() throws URISyntaxException {
-        // TODO: Consider ideas for testUseStandardVocabularies (see comment)
-        /* Possible ideas:
-           fetch resource, look for known vocabulary term
-           URIs.  Also can look at total number of terms and have a threshold
-           of differences, say 100 terms and < 5 standard predicates would be odd.
-           Also could look for similar/like short predicate short names or even
-           look for owl:sameAs.
-        */
-        throw new SkipNotTestableException();
-    }
+		// Make sure it parses as JSON-LD.
+		Object json = JsonUtils.fromInputStream(response.asInputStream());
+		JsonLdProcessor.toRDF(json); // throws JsonLdError if not valid
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "In the absence of special knowledge of the application "
-                    + "or domain, LDP clients MUST assume that any LDP-RS can "
-                    + "have multiple values for rdf:type.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldp-cli-multitype",
-            testMethod = METHOD.CLIENT_ONLY,
-            approval = STATUS.WG_APPROVED)
-    public void testAllowMultipleRdfTypes() {
-        throw new SkipClientTestException();
-    }
+	// Update a resource then later test if the updates were applied (i.e., on a subsequent GET).
+	// These methods could be overwritten by subclasses.
+	private final static String TITLE_FOR_UPDATE = "LDP Test Suite: This resource has been updated... " + System.currentTimeMillis();
 
-    @Test(
-            groups = {MUST},
-            description = "In the absence of special knowledge of the "
-                    + "application or domain, LDP clients MUST assume "
-                    + "that the rdf:type values of a given LDP-RS can "
-                    + "change over time.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-cli-typeschange",
-            testMethod = METHOD.CLIENT_ONLY,
-            approval = STATUS.WG_APPROVED)
-    public void testChangeRdfTypeValue() {
-        throw new SkipClientTestException();
-    }
+	/**
+	 * Update a resource then later test if the updates were applied (i.e., on a
+	 * subsequent GET). These methods could be overwritten by subclasses.
+	 *
+	 * @see #verifyUpdatedResource(Resource)
+	 */
+	protected void updateResource(Resource r) {
+		// Set a title.
+		r.removeAll(DCTerms.title);
+		r.addProperty(DCTerms.title, TITLE_FOR_UPDATE);
+	}
 
-    @Test(
-            groups = {SHOULD},
-            description = "LDP clients SHOULD always assume that the set "
-                    + "of predicates for a LDP-RS of a particular type at "
-                    + "an arbitrary server is open, in the sense that different "
-                    + "resources of the same type may not all have the same set "
-                    + "of predicates in their triples, and the set of predicates "
-                    + "that are used in the state of any one LDP-RS is not limited "
-                    + "to any pre-defined set.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-cli-openpreds",
-            testMethod = METHOD.CLIENT_ONLY,
-            approval = STATUS.WG_APPROVED)
-    public void testServerOpen() {
-        throw new SkipClientTestException();
-    }
+	/**
+	 * Update a resource then later test if the updates were applied (i.e., on a
+	 * subsequent GET). These methods could be overwritten by subclasses.
+	 *
+	 * @see #updateResource(Resource)
+	 */
+	protected void verifyUpdatedResource(Resource r) {
+		// Test the resource has the title we set.
+		assertTrue(r.hasProperty(DCTerms.title, TITLE_FOR_UPDATE), "Expected resource to have title \"" + TITLE_FOR_UPDATE + "\"");
+	}
 
-    @Test(
-            groups = {MUST},
-            description = "LDP servers MUST NOT require LDP clients to implement inferencing "
-                    + "in order to recognize the subset of content defined by LDP. Other "
-                    + "specifications built on top of LDP may require clients to implement "
-                    + "inferencing [rdf11-concepts]. The practical implication is that all "
-                    + "content defined by LDP must be explicitly represented, unless noted "
-                    + "otherwise within this document.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-gen-noinferencing",
-            testMethod = METHOD.MANUAL,
-            approval = STATUS.WG_APPROVED)
-    public void testRestrictClientInference() {
-        throw new SkipNotTestableException();
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "A LDP client MUST preserve all triples retrieved "
-                    + "from an LDP-RS using HTTP GET that it doesn’t change "
-                    + "whether it understands the predicates or not, when its "
-                    + "intent is to perform an update using HTTP PUT. The use of "
-                    + "HTTP PATCH instead of HTTP PUT for update avoids this "
-                    + "burden for clients [RFC5789]. ")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-cli-preservetriples",
-            testMethod = METHOD.MANUAL,
-            approval = STATUS.WG_APPROVED)
-    public void testGetResourcePreservesTriples() throws URISyntaxException {
-        throw new SkipNotTestableException();
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "LDP clients MUST be capable of processing responses "
-                    + "formed by an LDP server that ignores hints, including "
-                    + "LDP-defined hints.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-cli-hints-ignorable",
-            testMethod = METHOD.MANUAL,
-            approval = STATUS.WG_APPROVED)
-    public void testAllowResponsesFromServer() {
-        throw new SkipNotTestableException();
-    }
-
-    @Test(
-            groups = {MUST},
-            description = "LDP servers must provide a text/turtle representation "
-                    + "of the requested LDP-RS whenever HTTP content negotiation "
-                    + "does not force another outcome [turtle]. In other words, if "
-                    + "the server receives a GET request whose Request-URI "
-                    + "identifies a LDP-RS, and either text/turtle has the highest "
-                    + "relative quality factor (q= value) in the Accept request "
-                    + "header or that header is absent, then an LDP server has to "
-                    + "respond with Turtle.")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-get-turtle",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_APPROVED)
-    public void testGetResourceAcceptTurtle() {
-        // Accept: text/turtle
-        buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
-                .expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
-                .when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
-
-        // No Accept header
-        buildBaseRequestSpecification()
-                .expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
-                .when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
-
-        // Wildcard
-        buildBaseRequestSpecification().header(ACCEPT, "*/*")
-                .expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
-                .when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
-
-        // Accept: text/*
-        buildBaseRequestSpecification().header(ACCEPT, "text/*")
-                .expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
-                .when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
-
-        // More complicated Accept header
-        buildBaseRequestSpecification().header(ACCEPT, "text/turtle;q=0.9,application/json;q=0.8")
-                .expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
-                .when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
-    }
-    
-    /**
-     * This is a client-only test. Server tests are covered by
-     * {@link CommonContainerTest#testPreferContainmentTriples()} and
-     * {@link DirectContainerTest#testPreferMembershipTriples()}.
-     */
-    @Test(
-            enabled = false,
-            groups = {MAY},
-            description = "LDP clients MAY provide LDP-defined hints that allow servers "
-                    + "to optimize the content of responses. section 7.2 Preferences on "
-                    + "the Prefer Request Header defines hints that apply to LDP-RSs. ")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-cli-can-hint",
-            testMethod = METHOD.CLIENT_ONLY,
-            approval = STATUS.WG_PENDING)
-    public void testClientMayProvideHints() {
-        throw new SkipClientTestException();
-    }
-
-    @Test(
-            groups = {SHOULD},
-            description = "LDP servers SHOULD offer a application/ld+json representation"
-                    + " of the requested LDP-RS [JSON-LD]. ")
-    @SpecTest(
-            specRefUri = LdpTestSuite.SPEC_URI + "#ldprs-get-jsonld",
-            testMethod = METHOD.AUTOMATED,
-            approval = STATUS.WG_PENDING)
-    public void testJsonLdRepresentation() throws IOException, JsonLdError {
-        Response response = buildBaseRequestSpecification()
-                .header(ACCEPT, "application/ld+json, application/json;q=0.5")
-                .expect()
-                .statusCode(isSuccessful())
-                .contentType(HeaderMatchers.isJsonLdCompatibleContentType())
-                .when()
-                .get(getResourceUri());
-
-        // Make sure it parses as JSON-LD.
-        Object json = JsonUtils.fromInputStream(response.asInputStream());
-        JsonLdProcessor.toRDF(json); // throws JsonLdError if not valid
-    }
-
-    // Update a resource then later test if the updates were applied (i.e., on a subsequent GET).
-    // These methods could be overwritten by subclasses.
-    private final static String TITLE_FOR_UPDATE = "LDP Test Suite: This resource has been updated... " + System.currentTimeMillis();
-
-    /**
-     * Update a resource then later test if the updates were applied (i.e., on a
-     * subsequent GET). These methods could be overwritten by subclasses.
-     *
-     * @see #verifyUpdatedResource(Resource)
-     */
-    protected void updateResource(Resource r) {
-        // Set a title.
-        r.removeAll(DCTerms.title);
-        r.addProperty(DCTerms.title, TITLE_FOR_UPDATE);
-    }
-
-    /**
-     * Update a resource then later test if the updates were applied (i.e., on a
-     * subsequent GET). These methods could be overwritten by subclasses.
-     *
-     * @see #updateResource(Resource)
-     */
-    protected void verifyUpdatedResource(Resource r) {
-        // Test the resource has the title we set.
-        assertTrue(r.hasProperty(DCTerms.title, TITLE_FOR_UPDATE), "Expected resource to have title \"" + TITLE_FOR_UPDATE + "\"");
-    }
-
-    /**
-     * Are there any restrictions on resource content? This should be true for
-     * LDP containers since PUT is not allowed to modify containment triples.
-     *
-     * @return true if there are restrictions on what triples are allowed; false
-     * if the entire resource can be replaced with any triples
-     * @see #testPutReplacesResource
-     * @see CommonContainerTest#testRejectPutModifyingContainmentTriples
-     */
-    protected boolean restrictionsOnContent() {
-        return false;
-    }
+	/**
+	 * Are there any restrictions on resource content? This should be true for
+	 * LDP containers since PUT is not allowed to modify containment triples.
+	 *
+	 * @return true if there are restrictions on what triples are allowed; false
+	 * if the entire resource can be replaced with any triples
+	 * @see #testPutReplacesResource
+	 * @see CommonContainerTest#testRejectPutModifyingContainmentTriples
+	 */
+	protected boolean restrictionsOnContent() {
+		return false;
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/util/OptionsHandler.java
+++ b/src/main/java/org/w3/ldp/testsuite/util/OptionsHandler.java
@@ -7,54 +7,54 @@ import java.util.Map;
 
 public class OptionsHandler {
 
-    private final Map<String, String> options;
-    private final CommandLine cmd;
+	private final Map<String, String> options;
+	private final CommandLine cmd;
 
-    public OptionsHandler(final Map<String, String> options) {
-        this.options = options;
-        this.cmd = null;
-    }
+	public OptionsHandler(final Map<String, String> options) {
+		this.options = options;
+		this.cmd = null;
+	}
 
-    public OptionsHandler(final CommandLine cmd) {
-        this.cmd = cmd;
-        this.options = null;
-    }
+	public OptionsHandler(final CommandLine cmd) {
+		this.cmd = cmd;
+		this.options = null;
+	}
 
-    public boolean hasOption(String name) {
-        if (options == null) {
-            return cmd.hasOption(name);
-        }
+	public boolean hasOption(String name) {
+		if (options == null) {
+			return cmd.hasOption(name);
+		}
 
-        return options.containsKey(name);
-    }
+		return options.containsKey(name);
+	}
 
-    public boolean hasOptionWithValue(String name) {
-        if (options == null) {
-            return cmd.hasOption(name) && StringUtils.isNotBlank(cmd.getOptionValue(name));
-        }
+	public boolean hasOptionWithValue(String name) {
+		if (options == null) {
+			return cmd.hasOption(name) && StringUtils.isNotBlank(cmd.getOptionValue(name));
+		}
 
-        return options.containsKey(name) && StringUtils.isNotBlank(options.get(name));
-    }
+		return options.containsKey(name) && StringUtils.isNotBlank(options.get(name));
+	}
 
-    public String getOptionValue(String name) {
-        if (options == null) {
-            return cmd.getOptionValue(name);
-        }
+	public String getOptionValue(String name) {
+		if (options == null) {
+			return cmd.getOptionValue(name);
+		}
 
-        return options.get(name);
-    }
+		return options.get(name);
+	}
 
-    public String[] getOptionValues(String name) {
-        if (options == null) {
-            return cmd.getOptionValues(name);
-        }
+	public String[] getOptionValues(String name) {
+		if (options == null) {
+			return cmd.getOptionValues(name);
+		}
 
-        String[] values = options.get(name).split(",");
-        for (int i = 0; i < values.length; i++) {
-            values[i] = values[i].trim();
-        }
+		String[] values = options.get(name).split(",");
+		for (int i = 0; i < values.length; i++) {
+			values[i] = values[i].trim();
+		}
 
-        return values;
-    }
+		return values;
+	}
 
 }

--- a/src/main/java/org/w3/ldp/testsuite/vocab/LDP.java
+++ b/src/main/java/org/w3/ldp/testsuite/vocab/LDP.java
@@ -21,257 +21,257 @@ import org.openrdf.model.impl.ValueFactoryImpl;
  */
 public class LDP {
 
-    /**
-     * {@code http://www.w3.org/ns/ldp#} *
-     */
-    public static final String NAMESPACE = "http://www.w3.org/ns/ldp#";
+	/**
+	 * {@code http://www.w3.org/ns/ldp#} *
+	 */
+	public static final String NAMESPACE = "http://www.w3.org/ns/ldp#";
 
-    /**
-     * {@code ldp} *
-     */
-    public static final String PREFIX = "ldp";
+	/**
+	 * {@code ldp} *
+	 */
+	public static final String PREFIX = "ldp";
 
-    /**
-     * BasicContainer
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#BasicContainer}.
-     * <p/>
-     * An LDPC that uses a predefined predicate to simply link to its
-     * contained resources.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#BasicContainer">BasicContainer</a>
-     */
-    public static final URI BasicContainer;
+	/**
+	 * BasicContainer
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#BasicContainer}.
+	 * <p/>
+	 * An LDPC that uses a predefined predicate to simply link to its
+	 * contained resources.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#BasicContainer">BasicContainer</a>
+	 */
+	public static final URI BasicContainer;
 
-    /**
-     * Container
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#Container}.
-     * <p/>
-     * A Linked Data Platform RDF Source (LDP-RS) that also conforms to
-     * additional patterns and conventions for managing membership. Readers
-     * should refer to the specification defining this ontology for the list
-     * of behaviors associated with it.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#Container">Container</a>
-     */
-    public static final URI Container;
+	/**
+	 * Container
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#Container}.
+	 * <p/>
+	 * A Linked Data Platform RDF Source (LDP-RS) that also conforms to
+	 * additional patterns and conventions for managing membership. Readers
+	 * should refer to the specification defining this ontology for the list
+	 * of behaviors associated with it.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#Container">Container</a>
+	 */
+	public static final URI Container;
 
-    /**
-     * contains
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#contains}.
-     * <p/>
-     * Links a container with resources created through the container.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#contains">contains</a>
-     */
-    public static final URI contains;
+	/**
+	 * contains
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#contains}.
+	 * <p/>
+	 * Links a container with resources created through the container.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#contains">contains</a>
+	 */
+	public static final URI contains;
 
-    /**
-     * DirectContainer
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#DirectContainer}.
-     * <p/>
-     * An LDPC that is similar to a LDP-DC but it allows an indirection with
-     * the ability to list as member a resource, such as a URI representing a
-     * real-world object, that is different from the resource that is created
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#DirectContainer">DirectContainer</a>
-     */
-    public static final URI DirectContainer;
+	/**
+	 * DirectContainer
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#DirectContainer}.
+	 * <p/>
+	 * An LDPC that is similar to a LDP-DC but it allows an indirection with
+	 * the ability to list as member a resource, such as a URI representing a
+	 * real-world object, that is different from the resource that is created
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#DirectContainer">DirectContainer</a>
+	 */
+	public static final URI DirectContainer;
 
-    /**
-     * hasMemberRelation
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#hasMemberRelation}.
-     * <p/>
-     * Indicates which predicate is used in membership triples, and that the
-     * membership triple pattern is < membership-constant-URI ,
-     * object-of-hasMemberRelation, member-URI >.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#hasMemberRelation">hasMemberRelation</a>
-     */
-    public static final URI hasMemberRelation;
+	/**
+	 * hasMemberRelation
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#hasMemberRelation}.
+	 * <p/>
+	 * Indicates which predicate is used in membership triples, and that the
+	 * membership triple pattern is < membership-constant-URI ,
+	 * object-of-hasMemberRelation, member-URI >.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#hasMemberRelation">hasMemberRelation</a>
+	 */
+	public static final URI hasMemberRelation;
 
-    /**
-     * IndirectContainer
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#IndirectContainer}.
-     * <p/>
-     * An LDPC that has the flexibility of choosing what form the membership
-     * triples take.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#IndirectContainer">IndirectContainer</a>
-     */
-    public static final URI IndirectContainer;
+	/**
+	 * IndirectContainer
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#IndirectContainer}.
+	 * <p/>
+	 * An LDPC that has the flexibility of choosing what form the membership
+	 * triples take.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#IndirectContainer">IndirectContainer</a>
+	 */
+	public static final URI IndirectContainer;
 
-    /**
-     * insertedContentRelation
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#insertedContentRelation}.
-     * <p/>
-     * Indicates which triple in a creation request should be used as the
-     * member-URI value in the membership triple added when the creation
-     * request is successful.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#insertedContentRelation">insertedContentRelation</a>
-     */
-    public static final URI insertedContentRelation;
+	/**
+	 * insertedContentRelation
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#insertedContentRelation}.
+	 * <p/>
+	 * Indicates which triple in a creation request should be used as the
+	 * member-URI value in the membership triple added when the creation
+	 * request is successful.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#insertedContentRelation">insertedContentRelation</a>
+	 */
+	public static final URI insertedContentRelation;
 
-    /**
-     * isMemmberOfRelation
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#isMemberOfRelation}.
-     * <p/>
-     * Indicates which predicate is used in membership triples, and that the
-     * membership triple pattern is < member-URI ,
-     * object-of-isMemberOfRelation, membership-constant-URI >.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#isMemberOfRelation">isMemberOfRelation</a>
-     */
-    public static final URI isMemberOfRelation;
+	/**
+	 * isMemmberOfRelation
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#isMemberOfRelation}.
+	 * <p/>
+	 * Indicates which predicate is used in membership triples, and that the
+	 * membership triple pattern is < member-URI ,
+	 * object-of-isMemberOfRelation, membership-constant-URI >.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#isMemberOfRelation">isMemberOfRelation</a>
+	 */
+	public static final URI isMemberOfRelation;
 
-    /**
-     * member
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#member}.
-     * <p/>
-     * LDP servers should use this predicate as the membership predicate if
-     * there is no obvious predicate from an application vocabulary to use.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#member">member</a>
-     */
-    public static final URI member;
+	/**
+	 * member
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#member}.
+	 * <p/>
+	 * LDP servers should use this predicate as the membership predicate if
+	 * there is no obvious predicate from an application vocabulary to use.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#member">member</a>
+	 */
+	public static final URI member;
 
-    /**
-     * membershipResource
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#membershipResource}.
-     * <p/>
-     * Indicates the membership-constant-URI in a membership triple.
-     * Depending upon the membership triple pattern a container uses, as
-     * indicated by the presence of ldp:hasMemberRelation or
-     * ldp:isMemberOfRelation, the membership-constant-URI might occupy
-     * either the subject or object position in membership triples.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#membershipResource">membershipResource</a>
-     */
-    public static final URI membershipResource;
+	/**
+	 * membershipResource
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#membershipResource}.
+	 * <p/>
+	 * Indicates the membership-constant-URI in a membership triple.
+	 * Depending upon the membership triple pattern a container uses, as
+	 * indicated by the presence of ldp:hasMemberRelation or
+	 * ldp:isMemberOfRelation, the membership-constant-URI might occupy
+	 * either the subject or object position in membership triples.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#membershipResource">membershipResource</a>
+	 */
+	public static final URI membershipResource;
 
-    /**
-     * MemberSubject
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#MemberSubject}.
-     * <p/>
-     * Used to indicate default and typical behavior for
-     * ldp:insertedContentRelation, where the member-URI value in the
-     * membership triple added when a creation request is successful is the
-     * URI assigned to the newly created resource.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#MemberSubject">MemberSubject</a>
-     */
-    public static final URI MemberSubject;
+	/**
+	 * MemberSubject
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#MemberSubject}.
+	 * <p/>
+	 * Used to indicate default and typical behavior for
+	 * ldp:insertedContentRelation, where the member-URI value in the
+	 * membership triple added when a creation request is successful is the
+	 * URI assigned to the newly created resource.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#MemberSubject">MemberSubject</a>
+	 */
+	public static final URI MemberSubject;
 
-    /**
-     * NonRDFSource
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#NonRDFSource}.
-     * <p/>
-     * A Linked Data Platform Resource (LDPR) whose state is NOT represented
-     * as RDF.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#NonRDFSource">NonRDFSource</a>
-     */
-    public static final URI NonRDFSource;
+	/**
+	 * NonRDFSource
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#NonRDFSource}.
+	 * <p/>
+	 * A Linked Data Platform Resource (LDPR) whose state is NOT represented
+	 * as RDF.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#NonRDFSource">NonRDFSource</a>
+	 */
+	public static final URI NonRDFSource;
 
-    /**
-     * PreferContainment
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#PreferContainment}.
-     * <p/>
-     * URI identifying a LDPC's containment triples, for example to allow
-     * clients to express interest in receiving them.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#PreferContainment">PreferContainment</a>
-     */
-    public static final URI PreferContainment;
+	/**
+	 * PreferContainment
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#PreferContainment}.
+	 * <p/>
+	 * URI identifying a LDPC's containment triples, for example to allow
+	 * clients to express interest in receiving them.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#PreferContainment">PreferContainment</a>
+	 */
+	public static final URI PreferContainment;
 
-    /**
-     * PreferEmptyContainer
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#PreferEmptyContainer}.
-     * <p/>
-     * URI identifying the subset of a LDPC's triples present in an empty
-     * LDPC, for example to allow clients to express interest in receiving
-     * them. Currently this excludes containment and membership triples, but
-     * in the future other exclusions might be added. This definition is
-     * written to automatically exclude those new classes of triples.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#PreferEmptyContainer">PreferEmptyContainer</a>
-     */
-    public static final URI PreferEmptyContainer;
+	/**
+	 * PreferEmptyContainer
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#PreferEmptyContainer}.
+	 * <p/>
+	 * URI identifying the subset of a LDPC's triples present in an empty
+	 * LDPC, for example to allow clients to express interest in receiving
+	 * them. Currently this excludes containment and membership triples, but
+	 * in the future other exclusions might be added. This definition is
+	 * written to automatically exclude those new classes of triples.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#PreferEmptyContainer">PreferEmptyContainer</a>
+	 */
+	public static final URI PreferEmptyContainer;
 
-    /**
-     * PreferMembership
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#PreferMembership}.
-     * <p/>
-     * URI identifying a LDPC's membership triples, for example to allow
-     * clients to express interest in receiving them.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#PreferMembership">PreferMembership</a>
-     */
-    public static final URI PreferMembership;
+	/**
+	 * PreferMembership
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#PreferMembership}.
+	 * <p/>
+	 * URI identifying a LDPC's membership triples, for example to allow
+	 * clients to express interest in receiving them.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#PreferMembership">PreferMembership</a>
+	 */
+	public static final URI PreferMembership;
 
-    /**
-     * RDFSource
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#RDFSource}.
-     * <p/>
-     * A Linked Data Platform Resource (LDPR) whose state is represented as
-     * RDF.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#RDFSource">RDFSource</a>
-     */
-    public static final URI RDFSource;
+	/**
+	 * RDFSource
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#RDFSource}.
+	 * <p/>
+	 * A Linked Data Platform Resource (LDPR) whose state is represented as
+	 * RDF.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#RDFSource">RDFSource</a>
+	 */
+	public static final URI RDFSource;
 
-    /**
-     * Resource
-     * <p/>
-     * {@code http://www.w3.org/ns/ldp#Resource}.
-     * <p/>
-     * A HTTP-addressable resource whose lifecycle is managed by a LDP
-     * server.
-     *
-     * @see <a href="http://www.w3.org/ns/ldp#Resource">Resource</a>
-     */
-    public static final URI Resource;
+	/**
+	 * Resource
+	 * <p/>
+	 * {@code http://www.w3.org/ns/ldp#Resource}.
+	 * <p/>
+	 * A HTTP-addressable resource whose lifecycle is managed by a LDP
+	 * server.
+	 *
+	 * @see <a href="http://www.w3.org/ns/ldp#Resource">Resource</a>
+	 */
+	public static final URI Resource;
 
-    static {
-        ValueFactory factory = ValueFactoryImpl.getInstance();
+	static {
+		ValueFactory factory = ValueFactoryImpl.getInstance();
 
-        BasicContainer = factory.createURI(LDP.NAMESPACE, "BasicContainer");
-        Container = factory.createURI(LDP.NAMESPACE, "Container");
-        contains = factory.createURI(LDP.NAMESPACE, "contains");
-        DirectContainer = factory.createURI(LDP.NAMESPACE, "DirectContainer");
-        hasMemberRelation = factory.createURI(LDP.NAMESPACE, "hasMemberRelation");
-        IndirectContainer = factory.createURI(LDP.NAMESPACE, "IndirectContainer");
-        insertedContentRelation = factory.createURI(LDP.NAMESPACE, "insertedContentRelation");
-        isMemberOfRelation = factory.createURI(LDP.NAMESPACE, "isMemberOfRelation");
-        member = factory.createURI(LDP.NAMESPACE, "member");
-        membershipResource = factory.createURI(LDP.NAMESPACE, "membershipResource");
-        MemberSubject = factory.createURI(LDP.NAMESPACE, "MemberSubject");
-        NonRDFSource = factory.createURI(LDP.NAMESPACE, "NonRDFSource");
-        PreferContainment = factory.createURI(LDP.NAMESPACE, "PreferContainment");
-        PreferEmptyContainer = factory.createURI(LDP.NAMESPACE, "PreferEmptyContainer");
-        PreferMembership = factory.createURI(LDP.NAMESPACE, "PreferMembership");
-        RDFSource = factory.createURI(LDP.NAMESPACE, "RDFSource");
-        Resource = factory.createURI(LDP.NAMESPACE, "Resource");
-    }
+		BasicContainer = factory.createURI(LDP.NAMESPACE, "BasicContainer");
+		Container = factory.createURI(LDP.NAMESPACE, "Container");
+		contains = factory.createURI(LDP.NAMESPACE, "contains");
+		DirectContainer = factory.createURI(LDP.NAMESPACE, "DirectContainer");
+		hasMemberRelation = factory.createURI(LDP.NAMESPACE, "hasMemberRelation");
+		IndirectContainer = factory.createURI(LDP.NAMESPACE, "IndirectContainer");
+		insertedContentRelation = factory.createURI(LDP.NAMESPACE, "insertedContentRelation");
+		isMemberOfRelation = factory.createURI(LDP.NAMESPACE, "isMemberOfRelation");
+		member = factory.createURI(LDP.NAMESPACE, "member");
+		membershipResource = factory.createURI(LDP.NAMESPACE, "membershipResource");
+		MemberSubject = factory.createURI(LDP.NAMESPACE, "MemberSubject");
+		NonRDFSource = factory.createURI(LDP.NAMESPACE, "NonRDFSource");
+		PreferContainment = factory.createURI(LDP.NAMESPACE, "PreferContainment");
+		PreferEmptyContainer = factory.createURI(LDP.NAMESPACE, "PreferEmptyContainer");
+		PreferMembership = factory.createURI(LDP.NAMESPACE, "PreferMembership");
+		RDFSource = factory.createURI(LDP.NAMESPACE, "RDFSource");
+		Resource = factory.createURI(LDP.NAMESPACE, "Resource");
+	}
 
-    private LDP() {
-        //static access only
-    }
+	private LDP() {
+		//static access only
+	}
 
 }


### PR DESCRIPTION
Replace leading spaces with tabs so that we're consistently using tabs
for indentation.

Fixes #72
