### PR TITLE
Add doap:Developer information to Earl Report

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlReporter.java
@@ -10,6 +10,7 @@ import com.hp.hpl.jena.rdf.model.ModelFactory;
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.rdf.model.ResourceFactory;
 import com.hp.hpl.jena.sparql.vocabulary.DOAP;
+import com.hp.hpl.jena.sparql.vocabulary.FOAF;
 import com.hp.hpl.jena.vocabulary.DCTerms;
 
 import org.testng.*;
@@ -58,6 +59,7 @@ public class LdpEarlReporter implements IReporter {
 	private static String subjectName;
 	private static String refPage;
 	private static String language;
+	private static String mailBox;
 
 	static {
 		JenaJSONLD.init();
@@ -95,9 +97,21 @@ public class LdpEarlReporter implements IReporter {
 			subjectDev = suite.getParameter("developer");
 			language = suite.getParameter("language");
 
+			mailBox = suite.getParameter("mail");
+
 			// Make the Assertor Resource
 			Resource assertor = model.createResource(refPage, Earl.Assertor);
 			assertor.addProperty(DOAP.description, suite.getName());
+
+			/* Developer Resource (Person) */
+			Resource personResource = model.createResource(null, FOAF.Person);
+			if (mailBox != null && subjectDev != null) {
+				personResource.addProperty(FOAF.mbox, mailBox); // FIXME: Add in
+																// the mailto
+				personResource.addProperty(FOAF.name, subjectDev);
+			}
+
+			assertor.addProperty(DOAP.developer, personResource);
 
 			/* Software Resource */
 			Resource softResource = model
@@ -117,10 +131,6 @@ public class LdpEarlReporter implements IReporter {
 			if (subjectName != null)
 				subjectResource.addProperty(DOAP.name, subjectName);
 
-			if (subjectDev != null) {
-				subjectResource.addProperty(DOAP.developer, subjectDev);
-				// TODO acquire and add the information about the developer.
-			}
 			if (language != null)
 				subjectResource
 						.addProperty(DOAP.programming_language, language);

--- a/testng.xml
+++ b/testng.xml
@@ -18,11 +18,14 @@
       -->
     <parameter name="containerAsResource" value="http://localhost:8080/ldp/resources/bc/" />
     
+    <!-- Default values to plug into Properties in the Earl Report  -->
     <parameter name="language" value = "Java" />
     <parameter name="homepage" value ="http://wiki.eclipse.org/Lyo/LDPImpl" />
     <parameter name="referencePage" value="http://eclipse.org/lyo" />
     <parameter name="subjectName" value="Eclipse Lyo LDP Reference Implementation" />
     <parameter name="software" value="Reference Implementation" />
+    <parameter name="mail" value="sspeiche@gmail.com" />
+    <parameter name="developer" value="Steve Speicher" />
 
     <!-- Optional RDF member resource parameter. If left out, the tests will
         try to create a resource in one of the containers. -->


### PR DESCRIPTION
so that the earl-report tool can execute properly.  Takes in parameters from testng.xml
