### PR TITLE
Highlight MUST failures in html report

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpHtmlReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpHtmlReporter.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.text.DecimalFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -303,7 +304,13 @@ public class LdpHtmlReporter implements IReporter {
 		html.th(class_(title)).content("Description of Test Method")._tr();
 		for (ITestResult result : tests.getAllResults()) {
 			ITestNGMethod method = result.getMethod();
-			html.tr();
+			List<String> groups = Arrays.asList(method.getGroups());
+			if (groups.contains("MUST") && result.getStatus() == ITestResult.FAILURE) {
+				html.tr(class_("critical"));
+			} else {
+				html.tr();
+			}
+
 			html.td()
 					.a(href("#" + method.getTestClass().getName() + "_"
 							+ method.getMethodName()))

--- a/src/main/resources/reportStyle.css
+++ b/src/main/resources/reportStyle.css
@@ -69,3 +69,7 @@ td {
 	font-family: monospace;
 	font-size: 90%
 }
+
+.critical {
+	background-color: rgb(255, 158, 158);
+}


### PR DESCRIPTION
The test failures belonging to the MUST group  are highlighted in the report (Methods called section) in order to identify them quickly. This request changes the background color of the corresponding rows.
