### PR TITLE
don't HTML escape stacktrace twice in execution report

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpHtmlReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpHtmlReporter.java
@@ -484,7 +484,7 @@ public class LdpHtmlReporter implements IReporter {
 		html.table(class_("indented"));
 		html.tr(class_("center")).th(class_("Failed")).content("[FAILED TEST]")
 				._tr();
-		html.tr().td(class_("throw")).content(Utils.stackTrace(thrown, true)[0])._tr();
+		html.tr().td(class_("throw")).content(Utils.stackTrace(thrown, false)[0])._tr();
 
 		html._table();
 


### PR DESCRIPTION
Method content() already does the escaping.
