### PR TITLE
improve error handling on test setup errors

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
@@ -2,17 +2,18 @@ package org.w3.ldp.testsuite.test;
 
 import static org.hamcrest.Matchers.notNullValue;
 
+import java.io.IOException;
+
 import org.apache.http.HttpStatus;
 import org.testng.SkipException;
 import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.w3.ldp.testsuite.mapper.RdfObjectMapper;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.jayway.restassured.response.Response;
-
-import java.io.IOException;
 
 /**
  * Tests that run on an LDP-RS that is not a container.
@@ -22,11 +23,16 @@ public class MemberResourceTest extends RdfSourceTest {
 	private String container;
 	private String memberResource;
 
-	@Parameters({"memberResource", "directContainer", "indirectContainer", "basicContainer", "memberTtl", "auth"})
-	public MemberResourceTest(@Optional String memberResource, @Optional String directContainer,
-		@Optional String indirectContainer, @Optional String basicContainer,
-		@Optional String memberTtl, @Optional String auth) throws IOException {
+	@Parameters("auth")
+	public MemberResourceTest(@Optional String auth) throws IOException {
 		super(auth);
+	}
+
+	@Parameters({"memberResource", "directContainer", "indirectContainer", "basicContainer", "memberTtl"})
+	@BeforeSuite(alwaysRun = true)
+	public void setup(@Optional String memberResource, @Optional String directContainer,
+			@Optional String indirectContainer, @Optional String basicContainer,
+			@Optional String memberTtl) {
 		// If resource is defined, use that. Otherwise, fall back to creating one from one of the containers.
 		if (memberResource != null) {
 			this.memberResource = memberResource;
@@ -41,31 +47,42 @@ public class MemberResourceTest extends RdfSourceTest {
 		}
 
 		if (this.memberResource == null) {
-			Model model = this.readModel(memberTtl);
-			if (model == null) {
-				model = this.getDefaultModel();
+			try {
+				Model model = this.readModel(memberTtl);
+				if (model == null) {
+					model = this.getDefaultModel();
+				}
+
+				Response postResponse = buildBaseRequestSpecification()
+						.contentType(TEXT_TURTLE)
+							.body(model, new RdfObjectMapper())
+						.expect()
+							.statusCode(HttpStatus.SC_CREATED)
+							.header(LOCATION, notNullValue())
+						.when()
+							.post(this.container);
+
+				this.memberResource = postResponse.getHeader(LOCATION);
+			} catch (Exception e) {
+				System.err.println("ERROR: Could not create test resource for MemberResourceTest. Skipping tests.");
+				e.printStackTrace();
 			}
-
-			Response postResponse = buildBaseRequestSpecification()
-					.contentType(TEXT_TURTLE).body(model, new RdfObjectMapper())
-							.expect().statusCode(HttpStatus.SC_CREATED).header(LOCATION, notNullValue())
-							.when().post(this.container);
-
-			this.memberResource = postResponse.getHeader(LOCATION);
 		}
 	}
 
 	@Override
 	protected String getResourceUri() {
+		if (memberResource == null) {
+			throw new SkipException("Skipping test because test resource is null.");
+		}
 		return memberResource;
 	}
 
 	@AfterSuite(alwaysRun = true)
-	public void deleteTestResource() {
+	public void tearDown() {
 		// If container isn't null, we created the resource ourselves. To clean up, delete the resource.
 		if (container != null) {
 			buildBaseRequestSpecification().delete(memberResource);
 		}
 	}
-
 }


### PR DESCRIPTION
- Still run other tests if one test class can't be initialized.
- Print better errors to the console when an initialization error
  occurs.
