### PR TITLE
add @Documented to SpecTest annotation

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/annotations/SpecTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/annotations/SpecTest.java
@@ -1,8 +1,10 @@
 package org.w3.ldp.testsuite.annotations;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SpecTest {
 


### PR DESCRIPTION
This allows @SpecTest to be included in Javadocs.
