### PR TITLE
allow EARL test manifest to be generated during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,12 +267,37 @@
                         <version>1.1.1</version>
                         <executions>
                             <execution>
-                                <phase>test</phase>
+                                <id>generate-testsuite-coverage-report</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>java</goal>
                                 </goals>
                                 <configuration>
                                     <mainClass>org.w3.ldp.testsuite.reporter.LdpTestCaseReporter</mainClass>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-manifest</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.1.1</version>
+                        <executions>
+                            <execution>
+                                <id>generate-earl-test-manifest</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                                <configuration>
+                                    <mainClass>org.w3.ldp.testsuite.reporter.LdpEarlTestManifest</mainClass>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Add Maven profile "test-manifest" so that the manifest can be created
directly from Maven using the command

```
mvn install -Ptest-manifest
```

This is similar to the test-coverage profile we have already.
