### PR TITLE
remove profile test-coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,30 +258,6 @@
 
     <profiles>
         <profile>
-            <id>test-coverage</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.1.1</version>
-                        <executions>
-                            <execution>
-                                <id>generate-testsuite-coverage-report</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>java</goal>
-                                </goals>
-                                <configuration>
-                                    <mainClass>org.w3.ldp.testsuite.reporter.LdpTestCaseReporter</mainClass>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>test-manifest</id>
             <build>
                 <plugins>


### PR DESCRIPTION
Profile test-manifest now generates both HTML and EARL test case
reports, so remove the old profile.
