### PR TITLE
fix test-manifest profile in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,13 +267,22 @@
                         <version>1.1.1</version>
                         <executions>
                             <execution>
-                                <id>generate-test-manifest</id>
-                                <phase>package</phase>
+                                <id>generate-test-manifest-earl</id>
+                                <phase>compile</phase>
                                 <goals>
                                     <goal>java</goal>
                                 </goals>
                                 <configuration>
                                     <mainClass>org.w3.ldp.testsuite.reporter.LdpEarlTestManifest</mainClass>
+                                </configuration>
+                             </execution>
+                             <execution>
+                                <id>generate-test-manifest-html</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                                <configuration>
                                     <mainClass>org.w3.ldp.testsuite.reporter.LdpTestCaseReporter</mainClass>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
The EARL manifest was no longer getting generated with the test-manifest
profile during Maven builds.
