### PR TITLE
Apply Basic Authentication to the test suite

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
@@ -79,7 +79,7 @@ public abstract class CommonResourceTest extends LdpTest {
 		if (auth == null) {
 			return RestAssured.given();
 		} else {
-			return RestAssured.given().auth().basic(auth.get("username"), auth.get("password"));
+			return RestAssured.given().auth().preemptive().basic(auth.get("username"), auth.get("password"));
 		}
 	}
 

--- a/testng.xml
+++ b/testng.xml
@@ -27,6 +27,7 @@
     <parameter name="mail" value="jdoe@example.org" />
     <parameter name="developer" value="Jane Doe" />
     <parameter name="description" value="Testing against: BasicContainer, RDFSource, NonRDFSource, Prefer, Container as Resource interaction model." />
+    <parameter name="auth" value="admin:admin" />
     
 
     <!-- (Optional) RDF member resource parameter. If left out, the tests will


### PR DESCRIPTION
Adding Preemptive to the auth is needed in order to avoid a
NonRepeatableRequestException on test initialization
