### PR TITLE
better error handling during test setup failures

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
@@ -1,7 +1,5 @@
 package org.w3.ldp.testsuite.test;
 
-import static org.hamcrest.Matchers.notNullValue;
-
 import java.io.IOException;
 
 import org.apache.http.HttpStatus;
@@ -19,6 +17,7 @@ import com.jayway.restassured.response.Response;
  * Tests that run on an LDP-RS that is not a container.
  */
 public class MemberResourceTest extends RdfSourceTest {
+	private static final String SETUP_ERROR = "ERROR: Could not create test resource for MemberResourceTest. Skipping tests.";
 
 	private String container;
 	private String memberResource;
@@ -55,16 +54,24 @@ public class MemberResourceTest extends RdfSourceTest {
 
 				Response postResponse = buildBaseRequestSpecification()
 						.contentType(TEXT_TURTLE)
-							.body(model, new RdfObjectMapper())
-						.expect()
-							.statusCode(HttpStatus.SC_CREATED)
-							.header(LOCATION, notNullValue())
-						.when()
-							.post(this.container);
+						.body(model, new RdfObjectMapper())
+						.post(this.container);
+				if (postResponse.getStatusCode() != HttpStatus.SC_CREATED) {
+					System.err.println(SETUP_ERROR);
+					System.err.println("POST failed with status code: " + postResponse.getStatusCode());
+					System.err.println();
+					return;
+				}
 
 				this.memberResource = postResponse.getHeader(LOCATION);
+				if (this.memberResource == null) {
+					System.err.println(SETUP_ERROR);
+					System.err.println("Location response header missing");
+					System.err.println();
+					return;
+				}
 			} catch (Exception e) {
-				System.err.println("ERROR: Could not create test resource for MemberResourceTest. Skipping tests.");
+				System.err.println(SETUP_ERROR);
 				e.printStackTrace();
 			}
 		}

--- a/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
@@ -34,6 +34,7 @@ import com.jayway.restassured.response.Response;
  * Tests Non-RDF Source LDP resources.
  */
 public class NonRDFSourceTest extends CommonResourceTest {
+	private final static String SETUP_ERROR = "ERROR: Could not create test resource for NonRDFSourceTest. Skipping tests.";
 
 	private String container;
 	private URI containerType;
@@ -67,10 +68,27 @@ public class NonRDFSourceTest extends CommonResourceTest {
 
 		// Create a resource to use for CommonResourceTest.
 		try {
-			Response response = postNonRDFSource(slug, file, mimeType);
+			Response response = buildBaseRequestSpecification()
+					.header(SLUG, slug)
+					.body(IOUtils.toByteArray(getClass().getResourceAsStream("/" + file)))
+					.contentType(mimeType)
+					.post(container);
+			if (response.getStatusCode() != HttpStatus.SC_CREATED) {
+				System.err.println(SETUP_ERROR);
+				System.err.println("POST failed with status code: " + response.getStatusCode());
+				System.err.println();
+				return;
+			}
+
 			nonRdfSource = response.getHeader(LOCATION);
+			if (nonRdfSource == null) {
+				System.err.println(SETUP_ERROR);
+				System.err.println("Location response header missing");
+				System.err.println();
+				return;
+			}
 		} catch (Exception e) {
-			System.err.println("ERROR: Could not create test resource for NonRDFSourceTest. Skipping tests.");
+			System.err.println(SETUP_ERROR);
 			e.printStackTrace();
 		}
 	}


### PR DESCRIPTION
- Don't skip all tests when only one setup method fails
- Print errors to stderr

Fixes #153
