### PR TITLE
add --httpLogging option to log HTTP requests and responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.openrdf.sesame</groupId>

--- a/src/main/java/org/w3/ldp/testsuite/LdpTestSuite.java
+++ b/src/main/java/org/w3/ldp/testsuite/LdpTestSuite.java
@@ -46,8 +46,8 @@ import com.jayway.restassured.RestAssured;
 public class LdpTestSuite {
 
 	public static final String NAME = "LDP Test Suite";
-
 	public static final String SPEC_URI = "http://www.w3.org/TR/ldp";
+	public static final String OUTPUT_DIR = "report";
 
 	static final String[] EARLDEPEDENTARGS = {"software", "developer", "language", "homepage", "assertor", "shortname"};
 
@@ -243,6 +243,10 @@ public class LdpTestSuite {
 			testsuite.addIncludedGroup(LdpTest.NR);
 		}
 
+		if (options.hasOption("httpLogging")) {
+			parameters.put("httpLogging", "true");
+		}
+
 		test.setXmlClasses(classList);
 
 		final List<XmlTest> tests = new ArrayList<>();
@@ -398,6 +402,10 @@ public class LdpTestSuite {
 				.withDescription("which tests to run (* is a wildcard)")
 				.hasArgs().withArgName("test names")
 				.create());
+
+		common.addOption(OptionBuilder.withLongOpt("httpLogging")
+				.withDescription("log HTTP requests and responses on validation failures")
+				.isRequired(false).create());
 
 		common.addOption(OptionBuilder.withLongOpt("help")
 				.withDescription("prints this usage help").create());

--- a/src/main/java/org/w3/ldp/testsuite/reporter/AbstractEarlReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/AbstractEarlReporter.java
@@ -14,13 +14,11 @@ import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 
 public abstract class AbstractEarlReporter {
-
 	protected BufferedWriter writerTurtle;
 	protected BufferedWriter writerJson;
 	protected Model model;
 	protected static final String TURTLE = "TURTLE";
 	protected static final String JSON_LD = "JSON-LD";
-	protected static final String OUTPUT_DIR = "report";
 	protected static final HashMap<String, String> prefixes = new HashMap<String, String>();
 
 	static {
@@ -70,7 +68,7 @@ public abstract class AbstractEarlReporter {
 		model = ModelFactory.createDefaultModel();
 		writePrefixes(model);
 	}
-	
+
 	public void writePrefixes(Model model) {
 		for (Entry<String, String> prefix : prefixes.entrySet()) {
 			model.setNsPrefix(prefix.getKey(), prefix.getValue());

--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlReporter.java
@@ -19,6 +19,7 @@ import org.testng.ITestResult;
 import org.testng.annotations.Test;
 import org.testng.internal.Utils;
 import org.testng.xml.XmlSuite;
+import org.w3.ldp.testsuite.LdpTestSuite;
 import org.w3.ldp.testsuite.annotations.SpecTest;
 import org.w3.ldp.testsuite.annotations.SpecTest.METHOD;
 import org.w3.ldp.testsuite.vocab.Earl;
@@ -61,12 +62,12 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 	private static String mailBox;
 	private static String description;
 	private static String shortname;
-	
+
 	private static Property ranAsClass = ResourceFactory
 			.createProperty(LDP.LDPT_NAMESPACE + "ranAsClass");
-	
+
 	private static String TITLE = "ldp-testsuite";
-	
+
 	private IResultMap passedTests;
 	private IResultMap failedTests;
 	private IResultMap skippedTests;
@@ -75,7 +76,7 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 	public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites,
 			String outputDirectory) {
 		try {
-			createWriter(OUTPUT_DIR, "");
+			createWriter(LdpTestSuite.OUTPUT_DIR, "");
 		} catch (IOException e) {
 			e.printStackTrace(System.err);
 			System.exit(1);
@@ -108,13 +109,13 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 
 			mailBox = suite.getParameter("mbox");
 			description = suite.getParameter("description");
-			
+
 			shortname = suite.getParameter("shortname");
 
 			// Make the Assertor Resource
 			Resource assertorRes = model.createResource(assertor);
 			assertorRes.addProperty(RDF.type, Earl.Assertor);
-			
+
 			if (description != null)
 				assertorRes.addProperty(DOAP.description, description);
 
@@ -122,7 +123,7 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 			Resource personResource = model.createResource(null, FOAF.Person);
 			if (mailBox != null)
 				personResource.addProperty(FOAF.mbox, mailBox);
-			if(subjectDev != null) 
+			if(subjectDev != null)
 				personResource.addProperty(FOAF.name, subjectDev);
 
 			assertorRes.addProperty(DOAP.developer, personResource);
@@ -132,7 +133,7 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 					.createResource(assertor, Earl.Software);
 			if (softwareTitle != null)
 				softResource.addProperty(DCTerms.title, softwareTitle);
-			
+
 			if(shortname != null)
 				softResource.addProperty(DOAP.name, shortname);
 
@@ -140,7 +141,7 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 
 			Resource subjectResource = model.createResource(assertor,
 					Earl.TestSubject);
-			
+
 			subjectResource.addProperty(RDF.type, DOAP.Project);
 
 			if (homepage != null)
@@ -177,11 +178,11 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 		String className = result.getTestClass().getName();
 		className = className.substring(className
 				.lastIndexOf(".") + 1);
-		
+
 		Resource assertionResource = model.createResource(null, Earl.Assertion);
 
 		Resource resultResource = model.createResource(null, Earl.TestResult);
-		
+
 		Resource subjectResource = model.getResource(assertor);
 
 		assertionResource.addProperty(Earl.testSubject, subjectResource);
@@ -200,11 +201,11 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 					Method[] classMethod = classVal.getDeclaredMethods();
 					for(Method methodName : classMethod) {
 						if(methodName.getAnnotation(Test.class) != null) {
-							String group = Arrays.toString(methodName.getAnnotation(Test.class).groups()); 
+							String group = Arrays.toString(methodName.getAnnotation(Test.class).groups());
 							for(String groupCover : specTest.coveredByGroups()) {
 								if(group.contains(groupCover) && !methodName.getName().contains("Conforms")) {
 									testResults.add(findTestResult(methodName.getName()));
-								}								
+								}
 							}
 						}
 					}
@@ -268,7 +269,7 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 		assertionResource.addLiteral(ranAsClass, result.getTestClass().getRealClass().getSimpleName());
 
 		resultResource.addProperty(DCTerms.date, model.createTypedLiteral(GregorianCalendar.getInstance()));
-		
+
 		/*
 		 * Add the above resources to the Assertion Resource
 		 */
@@ -283,8 +284,8 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 			resource.addLiteral(DCTerms.description,
 					Utils.stackTrace(thrown, false)[0]);
 	}
-	
-	private String  findTestResult(String methodName) {		
+
+	private String  findTestResult(String methodName) {
 		Iterator<ITestNGMethod> passed = passedTests.getAllMethods().iterator();
 		while(passed.hasNext()){
 			ITestNGMethod method = passed.next();
@@ -292,7 +293,7 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 				return PASS;
 			}
 		}
-		
+
 		Iterator<ITestNGMethod> skipped = skippedTests.getAllMethods().iterator();
 		while(skipped.hasNext()){
 			ITestNGMethod method = skipped.next();
@@ -300,7 +301,7 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 				return SKIP;
 			}
 		}
-		
+
 		Iterator<ITestNGMethod> failed = failedTests.getAllMethods().iterator();
 		while(failed.hasNext()){
 			ITestNGMethod method = failed.next();
@@ -308,7 +309,7 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
 				return FAIL;
 			}
 		}
-		
+
 		return null;
 	}
 
@@ -316,7 +317,7 @@ public class LdpEarlReporter extends AbstractEarlReporter implements IReporter {
     protected String getFilename() {
 	    return TITLE + "-execution-report-earl";
     }
-	
+
 	public void setTitle(String title){
 		TITLE = title;
 	}

--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlTestManifest.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpEarlTestManifest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.testng.annotations.Test;
+import org.w3.ldp.testsuite.LdpTestSuite;
 import org.w3.ldp.testsuite.annotations.SpecTest;
 import org.w3.ldp.testsuite.annotations.SpecTest.METHOD;
 import org.w3.ldp.testsuite.vocab.LDP;
@@ -87,25 +88,25 @@ public class LdpEarlTestManifest extends AbstractEarlReporter {
 	 */
 	private static final Resource indirect = ResourceFactory
 			.createResource(LDP.LDPT_NAMESPACE + "indirect");
-	
+
 	/**
 	 * @see SpecTest.steps
 	 */
 	private static final Property steps = ResourceFactory
 			.createProperty(LDP.LDPT_NAMESPACE + "steps");
-	
+
 	/**
 	 * List of GROUPS to include in reporting
 	 */
 	private static List<String> conformanceLevels = new ArrayList<String>();
-	
+
 	public void setConformanceLevels(List<String> list){
 		conformanceLevels = list;
 	}
 
 	public void generate(Map<Class<?>, String> classes, String title) {
 		try {
-			createWriter(OUTPUT_DIR, title);
+			createWriter(LdpTestSuite.OUTPUT_DIR, title);
 			System.out.println("Writing test manifest...");
 			createModel();
 			writeTestClasses(classes);
@@ -169,7 +170,7 @@ public class LdpEarlTestManifest extends AbstractEarlReporter {
 			testLdp = method.getAnnotation(SpecTest.class);
 			test = method.getAnnotation(Test.class);
 			if(!testLdp.testMethod().equals(METHOD.INDIRECT)){
-				
+
 				Resource testCaseResource = createResource(className, method, test, testLdp, conformanceClasses);
 				testCaseResource.addProperty(RDF.type, EARL.TestCase);
 				switch (testLdp.testMethod()) {
@@ -196,14 +197,14 @@ public class LdpEarlTestManifest extends AbstractEarlReporter {
 						Method[] classMethod = coverTest.getDeclaredMethods();
 						for(Method m : classMethod) {
 							if(m.getAnnotation(Test.class) != null) {
-								String group = Arrays.toString(m.getAnnotation(Test.class).groups()); 
+								String group = Arrays.toString(m.getAnnotation(Test.class).groups());
 								for(String groupCover : testLdp.coveredByGroups()) {
 									if(group.contains(groupCover)) {
 										String testCaseName = createTestCaseName(m.getDeclaringClass().getCanonicalName(), m.getName());
 										String testCaseURL = LDP.LDPT_NAMESPACE + testCaseName;
 										indirectResource.addProperty(DCTerms.hasPart, testCaseURL);
-										
-									}									
+
+									}
 								}
 							}
 						}
@@ -214,11 +215,11 @@ public class LdpEarlTestManifest extends AbstractEarlReporter {
 		}
 		return null;
 	}
-	
+
 	private Resource createResource(String className, Method method, Test test, SpecTest testLdp,
 			ArrayList<ArrayList<Resource>> conformanceClasses) {
 		String testCaseName = createTestCaseName(className, method.getName());
-		
+
 		// Client only tests should be managed in separate EARL manifest
 		if (testLdp.testMethod() == METHOD.CLIENT_ONLY) {
 			System.err.println("Wrongly received CLIENT_ONLY test for "+testCaseName+
@@ -243,8 +244,8 @@ public class LdpEarlTestManifest extends AbstractEarlReporter {
 		resource.addProperty(RDFS.comment, test.description());
 		if (allGroups != null)
 			resource.addProperty(DCTerms.subject, allGroups);
-	
-		boolean added = false;		
+
+		boolean added = false;
 		if (testLdp.approval() != SpecTest.STATUS.WG_EXTENSION) {
 			for (String group: test.groups()) {
 				group = group.trim();
@@ -259,7 +260,7 @@ public class LdpEarlTestManifest extends AbstractEarlReporter {
 		if (!added) {
 			conformanceClasses.get(LdpTestCaseReporter.OTHER).add(resource);
 		}
-	 
+
 		String[] stepsArr = testLdp.steps();
 		if (stepsArr != null && stepsArr.length > 0) {
 			ArrayList<Literal> arr = new ArrayList<Literal>();
@@ -272,7 +273,7 @@ public class LdpEarlTestManifest extends AbstractEarlReporter {
 
 		// 	Leave action property only to make earl-report happy
 		resource.addProperty(TestManifest.action, "");
-	
+
 		switch (testLdp.approval()) {
 		case WG_APPROVED:
 			resource.addProperty(TestDescription.reviewStatus, TestDescription.approved);
@@ -292,7 +293,7 @@ public class LdpEarlTestManifest extends AbstractEarlReporter {
 			specRef = model.createResource(testLdp.specRefUri());
 			resource.addProperty(RDFS.seeAlso, specRef);
 		}
-		
+
 		if (test.description() != null && test.description().length() > 0) {
 			Resource excerpt = model.createResource(TestDescription.Excerpt);
 			excerpt.addLiteral(TestDescription.includesText, test.description());
@@ -304,9 +305,9 @@ public class LdpEarlTestManifest extends AbstractEarlReporter {
 
 		resource.addProperty(documentation,
 				model.createResource(ReportUtils.getJavadocLink(method)));
-		
+
 		return resource;
-		
+
 	}
 
 	private String groups(String[] list) {

--- a/src/main/java/org/w3/ldp/testsuite/reporter/LdpHtmlReporter.java
+++ b/src/main/java/org/w3/ldp/testsuite/reporter/LdpHtmlReporter.java
@@ -12,9 +12,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -150,13 +147,8 @@ public class LdpHtmlReporter implements IReporter {
 				html._body()._html();
 
 				// send html to a file
-				createWriter("report", html.toHtml(), outputName);
-
-				Files.copy(getClass().getResourceAsStream("/testng-reports.css"),
-						new File(outputDirectory, "testng-reports.css").toPath(),
-						StandardCopyOption.REPLACE_EXISTING);
+				createWriter(LdpTestSuite.OUTPUT_DIR, html.toHtml(), outputName);
 			}
-
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
@@ -2,10 +2,14 @@ package org.w3.ldp.testsuite.test;
 
 import static org.w3.ldp.testsuite.matcher.HttpStatusSuccessMatcher.isSuccessful;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.text.DateFormat;
+import java.util.Date;
 import java.util.List;
 
 import javax.ws.rs.core.Link;
@@ -13,9 +17,11 @@ import javax.ws.rs.core.Link;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.marmotta.commons.vocabulary.LDP;
 import org.jboss.resteasy.plugins.delegates.LinkDelegate;
+import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
+import org.w3.ldp.testsuite.LdpTestSuite;
 import org.w3.ldp.testsuite.http.HttpHeaders;
 import org.w3.ldp.testsuite.http.LdpPreferences;
 import org.w3.ldp.testsuite.http.MediaTypes;
@@ -32,11 +38,17 @@ import com.jayway.restassured.response.Response;
 import com.jayway.restassured.specification.RequestSpecification;
 
 public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences {
+	public final static String HTTP_LOG_FILENAME = "http.log";
 
 	/**
 	 * Alternate content to use on POST requests
 	 */
 	private static Model postModel;
+
+	/**
+	 * For HTTP details on validation failures
+	 */
+	protected PrintStream httpLog;
 
 	/**
 	 * Builds a model from a turtle representation in a file
@@ -76,12 +88,37 @@ public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences
 	 * Initialization of generic resource model. This will run only once
 	 * at the beginning of the test suite, so postModel static field
 	 * will be assigned once too.
-	 * @param postTtl
+	 *
+	 * @param postTtl the resource with Turtle content to use for POST requests
+	 * @param httpLogging whether to log HTTP request and response details on errors
 	 */
 	@BeforeSuite(alwaysRun = true)
-	@Parameters("postTtl")
-	public void setPostContent(@Optional String postTtl) {
-		postModel = this.readModel(postTtl);
+	@Parameters({"postTtl", "httpLogging"})
+	public void setup(@Optional String postTtl, @Optional String httpLogging) {
+		postModel = readModel(postTtl);
+		if ("true".equals(httpLogging)) {
+			File dir = new File(LdpTestSuite.OUTPUT_DIR);
+			dir.mkdirs();
+			File file = new File(dir, HTTP_LOG_FILENAME);
+			try {
+				httpLog = new PrintStream(file);
+
+				// Add the date to the top of the log
+				DateFormat df = DateFormat.getDateTimeInstance();
+				httpLog.println("LDP Test Suite: HTTP Log (" + df.format(new Date()) + ")");
+				httpLog.println();
+			} catch (IOException e) {
+				System.err.println("WARNING: Error creating http.log for detailed errors");
+				e.printStackTrace();
+			}
+		}
+	}
+
+	@AfterSuite(alwaysRun = true)
+	public void tearDown() {
+		if (httpLog != null) {
+			httpLog.close();
+		}
 	}
 
 	/**
@@ -108,7 +145,7 @@ public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences
 	 * @see <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>
 	 */
 	public static final String MAY = "MAY";
-	
+
 
 	/**
 	 * A grouping of tests that may not need to run as part of the regular
@@ -131,6 +168,11 @@ public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences
 	public static boolean getWarnings() {
 		return warnings;
 	}
+
+	/**
+	 * If true, log HTTP request and response details on errors.
+	 */
+	protected boolean httpLogging = false;
 
 	/**
 	 * Build a base RestAssured {@link com.jayway.restassured.specification.RequestSpecification}.
@@ -180,8 +222,8 @@ public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences
 	 * </p>
 	 *
 	 * @return true if there are restrictions on what triples are allowed; false
-	 *         if the server allows most any RDF
-	 * @see #setPostContent(String)
+	 *		   if the server allows most any RDF
+	 * @see #setup(String)
 	 * @see RdfSourceTest#restrictionsOnTestResourceContent()
 	 */
 	protected boolean restrictionsOnPostContent() {
@@ -195,11 +237,11 @@ public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences
 	 * String, Response)}.
 	 *
 	 * @param expectedUri
-	 *            the expected URI
+	 *			  the expected URI
 	 * @param expectedRel
-	 *            the expected link relation (rel)
+	 *			  the expected link relation (rel)
 	 * @param response
-	 *            the HTTP response
+	 *			  the HTTP response
 	 * @see <a href="http://tools.ietf.org/html/rfc5988">RFC 5988</a>
 	 * @see #getFirstLinkForRelation(String, String, Response)
 	 */
@@ -213,13 +255,13 @@ public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences
 	 * URI if necessary.
 	 *
 	 * @param expectedLinkUri
-	 *            the expected URI
+	 *			  the expected URI
 	 * @param expectedRel
-	 *            the expected link relation (rel)
+	 *			  the expected link relation (rel)
 	 * @param requestUri
-	 *            the HTTP request URI (for resolving relative URIs)
+	 *			  the HTTP request URI (for resolving relative URIs)
 	 * @param response
-	 *            the HTTP response
+	 *			  the HTTP response
 	 * @see <a href="http://tools.ietf.org/html/rfc5988">RFC 5988</a>
 	 * @see #getFirstLinkForRelation(String, String, Response)
 	 */
@@ -245,11 +287,11 @@ public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences
 	 * Resolves relative URIs against the request URI if necessary.
 	 *
 	 * @param rel
-	 *            the expected link relation
+	 *			  the expected link relation
 	 * @param requestUri
-	 *            the HTTP request URI (for resolving relative URIs)
+	 *			  the HTTP request URI (for resolving relative URIs)
 	 * @param response
-	 *            the HTTP response
+	 *			  the HTTP response
 	 * @return the first link or {@code null} if none was found
 	 * @see <a href="http://tools.ietf.org/html/rfc5988">RFC 5988</a>
 	 * @see #containsLinkHeader(String, String, Response)
@@ -306,12 +348,12 @@ public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences
 	 * Resolves a URI if it's a relative path.
 	 *
 	 * @param base
-	 *            the base URI to use
+	 *			  the base URI to use
 	 * @param toResolve
-	 *            a URI that might be relative
+	 *			  a URI that might be relative
 	 * @return the resolved URI
 	 * @throws URISyntaxException
-	 *             on bad URIs (but relative URIs are OK)
+	 *			   on bad URIs (but relative URIs are OK)
 	 */
 	public static String resolveIfRelative(String base, String toResolve) {
 		try {


### PR DESCRIPTION
The option will log the HTTP request and response into a file called
http.log on validation failures along with some error details. This can
also be set in a testng.xml file using

```
<parameter name="httpLogging" value="true" />
```

This feature requires we move from rest-assured 2.3.0 to 2.3.1.

Fixes #156
