### PR TITLE
don't require Preference-Applied response header

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
@@ -46,7 +46,6 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 
 	public static final String MSG_LOC_NOTFOUND = "Location header missing after POST create.";
 	public static final String MSG_MBRRES_NOTFOUND = "Unable to locate object in triple with predicate ldp:membershipResource.";
-	public static final String MSG_PREFERENCE_NOT_APPLIED = "Server did not return Preference-Applied: return=representation response header";
 
 	@Parameters("auth")
 	public CommonContainerTest(@Optional String auth) throws IOException {
@@ -173,7 +172,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 					.get(containerUri);
 		model = response.as(Model.class, new RdfObjectMapper(containerUri));
 
-		assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
+		checkPreferenceAppliedHeader(response);
 
 		// Assumes the container is not empty.
 		assertTrue(model.contains(model.getResource(containerUri), model.createProperty(LDP.contains.stringValue())),
@@ -189,7 +188,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 					.get(containerUri);
 		model = response.as(Model.class, new RdfObjectMapper(containerUri));
 
-		assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
+		checkPreferenceAppliedHeader(response);
 		assertFalse(model.contains(model.getResource(containerUri), model.createProperty(LDP.contains.stringValue())),
 				"Container has containment triples when minimal container was requested");
 
@@ -203,7 +202,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 					.get(containerUri);
 		model = response.as(Model.class, new RdfObjectMapper(containerUri));
 
-		assertTrue(isPreferenceApplied(response), MSG_PREFERENCE_NOT_APPLIED);
+		checkPreferenceAppliedHeader(response);
 
 		// Assumes the container is not empty.
 		assertFalse(model.contains(model.getResource(containerUri), model.createProperty(LDP.contains.stringValue())),
@@ -832,7 +831,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 		assertFalse(containsLinkHeader(LDP.NonRDFSource.stringValue(), LINK_REL_TYPE, getResponse),
 				"Resources POSTed using JSON-LD should be treated as RDF source");
 	}
-	
+
 	@Test(
 			groups = {MUST},
 			description = "Each Linked Data Platform Container MUST "

--- a/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
@@ -1,5 +1,6 @@
 package org.w3.ldp.testsuite.test;
 
+import static org.testng.Assert.assertTrue;
 import static org.w3.ldp.testsuite.matcher.HttpStatusSuccessMatcher.isSuccessful;
 
 import java.io.File;
@@ -362,16 +363,25 @@ public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences
 	}
 
 	/**
-	 * Checks the response for a
-	 * <code>Preference-Applied: return=representation</code> response header.
+	 * Asserts the response has a <code>Preference-Applied:
+	 * return=representation</code> response header, but only if at
+	 * least one <code>Preference-Applied</code> header is present.
 	 *
 	 * @param response
 	 *			  the HTTP response
-	 * @return true if and only if the response contains the expected
-	 *		   <code>Preference-Applied</code> header
 	 */
-	protected boolean isPreferenceApplied(Response response) {
+	protected void checkPreferenceAppliedHeader(Response response) {
 		List<Header> preferenceAppliedHeaders = response.getHeaders().getList(PREFERNCE_APPLIED);
+		if (preferenceAppliedHeaders.isEmpty()) {
+			// The header is not mandatory.
+			return;
+		}
+
+		assertTrue(hasReturnRepresentation(preferenceAppliedHeaders),
+				"Server responded with a Preference-Applied header, but it did not contain return=representation");
+	}
+
+	protected boolean hasReturnRepresentation(List<Header> preferenceAppliedHeaders) {
 		for (Header h : preferenceAppliedHeaders) {
 			// Handle optional whitespace, quoted preference token values, and
 			// other tokens in the Preference-Applied response header.


### PR DESCRIPTION
The Preference-Applied header isn't required by LDP or RDF 7240. Since
we can tell if the client hint was honored from the content, don't fail
servers that don't use the header. If the header is present, however,
make sure it contains return=representation.

Fixes #155
