### PR TITLE
Added the option to define the ldp:insertedContentRelation that the IndirectContainer will use

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/IndirectContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/IndirectContainerTest.java
@@ -1,7 +1,11 @@
 package org.w3.ldp.testsuite.test;
 
-import com.jayway.restassured.response.Response;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+
 import org.apache.http.HttpStatus;
+import org.apache.marmotta.commons.constants.Namespace.FOAF;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Optional;
@@ -13,18 +17,24 @@ import org.w3.ldp.testsuite.annotations.SpecTest.METHOD;
 import org.w3.ldp.testsuite.annotations.SpecTest.STATUS;
 import org.w3.ldp.testsuite.vocab.LDP;
 
-import java.io.IOException;
-
-import static org.testng.Assert.assertTrue;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.Property;
+import com.hp.hpl.jena.rdf.model.Resource;
+import com.hp.hpl.jena.rdf.model.ResourceFactory;
+import com.jayway.restassured.response.Response;
 
 public class IndirectContainerTest extends CommonContainerTest {
-
+	// Default Inserted Content Relation
+	private final static String DEFAULT_ICR = FOAF.primaryTopic;
+	
 	private String indirectContainer;
-
-	@Parameters({"indirectContainer", "auth"})
-	public IndirectContainerTest(@Optional String indirectContainer, @Optional String auth) throws IOException {
+	private Property insertedContentRelation;
+	
+	@Parameters({"indirectContainer", "auth", "insertedContentRelation"})
+	public IndirectContainerTest(@Optional String indirectContainer, @Optional String auth, @Optional String insertedContentRelation) throws IOException {
 		super(auth);
 		this.indirectContainer = indirectContainer;
+		this.insertedContentRelation = ResourceFactory.createProperty(insertedContentRelation);
 	}
 
 	@BeforeClass(alwaysRun = true)
@@ -33,6 +43,19 @@ public class IndirectContainerTest extends CommonContainerTest {
 			throw new SkipException(
 					"No indirectContainer parameter provided in testng.xml. Skipping ldp:IndirectContainer tests.");
 		}
+		if(insertedContentRelation == null) {
+			insertedContentRelation = ResourceFactory.createProperty(DEFAULT_ICR);
+		}
+	}
+	
+	@Override
+	protected Model getDefaultModel() {
+		Model model = super.getDefaultModel();
+		Resource resource = model.getResource("");
+		resource.addProperty(insertedContentRelation,
+				model.createResource("#me"));
+
+		return model;
 	}
 
 	// TODO implement tests, signatures are from LDP spec

--- a/testng.xml
+++ b/testng.xml
@@ -10,6 +10,8 @@
     <parameter name="basicContainer" value="http://localhost:8080/ldp/resources/bc/"/>
     <!-- <parameter name="directContainer" value="http://localhost:8080/ldp/resources/dc-simple/" /> -->
     <!-- <parameter name="indirectContainer" value="http://localhost:8080/ldp/resources/" /> -->
+    <!-- (Optional) Inserted Content Relation that the IndirectContainer uses -->
+    <!-- <parameter name="insertedContentRelation" value="http://purl.org/dc/elements/1.1/relation" /> -->
     
     <!-- A resource whose internal RDF state has a type triple of one of container types
          but whose interaction model was created with header on POST request of:


### PR DESCRIPTION
See section 5.5.1.2.
IndirectContainers use the property ldp:insertedContentRelation to specify the indirection. The current implementation didn't specified this property on the resource it was posting, so it was failing as a Bad Request.

A new option was added to the main .xml file. It is optional because it was also included a default one, foaf:primaryTopic, which will be used if the option is not specified.
