### PR TITLE
Use new-style RestAssured DSL on testContentTypeHeader to avoid triggering a RestAssured bug that sends an invalid Accept header

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
@@ -418,11 +418,12 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 
 		try {
 			Response getResponse = buildBaseRequestSpecification()
-				.expect()
-					.statusCode(isSuccessful())
-					.contentType(not(TEXT_TURTLE))
 				.when()
-					.get(location);
+					.get(location)
+				.then().assertThat()
+					.statusCode(isSuccessful())
+					.and().contentType(not(TEXT_TURTLE))
+				.extract().response();
 
 			// Also make sure there is no Link header indicating this is an RDF source.
 			assertFalse(containsLinkHeader(LDP.RDFSource.stringValue(), LINK_REL_TYPE, getResponse),


### PR DESCRIPTION
Tests that use a matcher to check the value of a `Content-Type` header (such as [testContentTypeHeader](https://github.com/w3c/ldp-testsuite/blob/master/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java#L391)) seem to trigger a bug in the RestAssured library that results in a bad request sent to the LDP server.

The request, as written:

``` java
            Response getResponse = buildBaseRequestSpecification()
                .expect()
                    .statusCode(isSuccessful())
                    .contentType(not(TEXT_TURTLE))
                .when()
                    .get(location);
```

Results in this request:

``` console
3 > GET http://localhost:8080/rest/fe/8b/4a/2a/fe8b4a2a-2e09-46f2-b8fb-520f059dc095/fcr:content
3 > Accept: not "text/turtle"
```

Note that the Accept header is not syntactically valid, and strict servers (e.g. Jersey, in our case) will reject the request immediately.

It looks like the new style DSL of RestAssured avoids this problem.
