### PR TITLE
Update RestAssured library to 2.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>2.3.1</version>
+            <version>2.3.3</version>
         </dependency>
         <dependency>
             <groupId>org.openrdf.sesame</groupId>


### PR DESCRIPTION
Here's the upstream changelog:

https://raw.githubusercontent.com/jayway/rest-assured/master/changelog.txt

Of particular interest:
- com.jayway.restassured.internal.print.ResponsePrinter now returns the entire response (including headers, parameters etc) and not just the body.
- Fixed so that request and response is logged when "enableLoggingOfRequestAndResponseIfValidationFails" is defined when a response specifications fails to validate (issue 350).
