### PR TITLE
check for anchor parameter in Link headers

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/BasicContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/BasicContainerTest.java
@@ -1,7 +1,9 @@
 package org.w3.ldp.testsuite.test;
 
-import com.jayway.restassured.response.Response;
-import org.apache.http.HttpStatus;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Optional;
@@ -13,9 +15,7 @@ import org.w3.ldp.testsuite.annotations.SpecTest.METHOD;
 import org.w3.ldp.testsuite.annotations.SpecTest.STATUS;
 import org.w3.ldp.testsuite.vocab.LDP;
 
-import java.io.IOException;
-
-import static org.testng.Assert.assertTrue;
+import com.jayway.restassured.response.Response;
 
 public class BasicContainerTest extends CommonContainerTest {
 
@@ -26,7 +26,7 @@ public class BasicContainerTest extends CommonContainerTest {
 		super(auth);
 		this.basicContainer = basicContainer;
 	}
-	
+
 	@Test(
 			groups = {MUST},
 			description = "Each LDP Basic Container MUST also be a "
@@ -67,13 +67,17 @@ public class BasicContainerTest extends CommonContainerTest {
 					+ "IndirectContainerTest.testContainerSupportsHttpLinkHeader "
 					+ "covers the rest.")
 	public void testContainerSupportsHttpLinkHeader() {
-		Response response = buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
-				.expect().statusCode(HttpStatus.SC_OK).when()
-				.get(basicContainer);
+		Response response = buildBaseRequestSpecification().get(basicContainer);
 		assertTrue(
-				containsLinkHeader(LDP.BasicContainer.stringValue(), LINK_REL_TYPE,
-						response),
-				"LDP BasicContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <"
+				containsLinkHeader(
+						basicContainer,
+						LINK_REL_TYPE,
+						LDP.BasicContainer.stringValue(),
+						basicContainer,
+						response
+				),
+				"LDP BasicContainers must advertise their LDP support by exposing " +
+						"a HTTP Link header with a URI matching <"
 						+ LDP.BasicContainer.stringValue() + "> and rel='type'"
 		);
 	}

--- a/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonResourceTest.java
@@ -183,11 +183,18 @@ public abstract class CommonResourceTest extends LdpTest {
 			testMethod = METHOD.AUTOMATED,
 			approval = STATUS.WG_APPROVED)
 	public void testLdpLinkHeader() {
+		final String uri = getResourceUri();
 		Response response = buildBaseRequestSpecification()
-				.expect().statusCode(isSuccessful())
-				.when().get(getResourceUri());
+				.when()
+					.get(getResourceUri());
 		assertTrue(
-				containsLinkHeader(LDP.Resource.stringValue(), LINK_REL_TYPE, response),
+				containsLinkHeader(
+						uri,
+						LINK_REL_TYPE,
+						LDP.Resource.stringValue(),
+						uri,
+						response
+				),
 				"4.2.1.4 LDP servers exposing LDPRs must advertise their LDP support by exposing a HTTP Link header "
 						+ "with a target URI of http://www.w3.org/ns/ldp#Resource, and a link relation type of type (that is, "
 						+ "rel='type') in all responses to requests made to the LDPR's HTTP Request-URI. Actual: "

--- a/src/main/java/org/w3/ldp/testsuite/test/DirectContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/DirectContainerTest.java
@@ -76,7 +76,13 @@ public class DirectContainerTest extends CommonContainerTest {
 				.expect().statusCode(HttpStatus.SC_OK).when()
 				.get(directContainer);
 		assertTrue(
-				containsLinkHeader(LDP.DirectContainer.stringValue(), LINK_REL_TYPE, response),
+				containsLinkHeader(
+						directContainer,
+						LINK_REL_TYPE,
+						LDP.DirectContainer.stringValue(),
+						directContainer,
+						response
+				),
 				"LDP DirectContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <" + LDP.DirectContainer.stringValue() + "> and rel='type'");
 	}
 

--- a/src/main/java/org/w3/ldp/testsuite/test/IndirectContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/IndirectContainerTest.java
@@ -57,8 +57,13 @@ public class IndirectContainerTest extends CommonContainerTest {
 				.expect().statusCode(HttpStatus.SC_OK).when()
 				.get(indirectContainer);
 		assertTrue(
-				containsLinkHeader(LDP.IndirectContainer.stringValue(), LINK_REL_TYPE,
-						response),
+				containsLinkHeader(
+						indirectContainer,
+						LINK_REL_TYPE,
+						LDP.IndirectContainer.stringValue(),
+						indirectContainer,
+						response
+				),
 				"LDP DirectContainers must advertise their LDP support by exposing a HTTP Link header with a URI matching <"
 						+ LDP.IndirectContainer.stringValue()
 						+ "> and rel='type'"

--- a/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
@@ -477,7 +477,8 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 
 	protected void expectPut4xxDescribedBy(String invalidProp) {
 		Response putResponse = expectPut4xxStatus(invalidProp);
-		String describedby = getFirstLinkForRelation(LINK_REL_DESCRIBEDBY, getResourceUri(), putResponse);
+		final String uri = getResourceUri();
+		String describedby = getFirstLinkForRelation(uri, LINK_REL_DESCRIBEDBY, uri, putResponse);
 		assertNotNull(describedby, "Response did not contain a Link header with rel=\"describedby\"");
 
 		// Make sure we can GET the describedby link.


### PR DESCRIPTION
Responses to POST requests that contain links for the newly-created
resource should include an anchor parameter to set the Link context.
