### PR TITLE
Allow Preference-Applied header check to include characters before or after the substring

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
@@ -377,7 +377,7 @@ public abstract class LdpTest implements HttpHeaders, MediaTypes, LdpPreferences
 		for (Header h : preferenceAppliedHeaders) {
 			// Handle optional whitespace, quoted preference token values, and
 			// other tokens in the Preference-Applied response header.
-			if (h.getValue().matches("(^|[ ;])return *= *\"?representation\"?($|[ ;])")) {
+			if (h.getValue().matches("(^|.*[ ;])return *= *\"?representation\"?($|[ ;].*)")) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Without this change, a response including other data won't match, e.g.:

```
Preference-Applied: return=representation; include="http://www.w3.org/ns/ldp#PreferMembership http://www.w3.org/ns/ldp#PreferContainment"
```
