### PR TITLE
Use SkipException instead of System.out.println() in test setup

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
@@ -3,6 +3,8 @@ package org.w3.ldp.testsuite.test;
 import java.io.IOException;
 
 import org.apache.http.HttpStatus;
+import org.hamcrest.CoreMatchers;
+import org.testng.Assert;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Optional;
@@ -54,26 +56,28 @@ public class MemberResourceTest extends RdfSourceTest {
 				}
 
 				Response postResponse = buildBaseRequestSpecification()
+					.with()
 						.contentType(TEXT_TURTLE)
 						.body(model, new RdfObjectMapper())
-						.post(this.container);
+					//.expect()
+					//	.header(LOCATION, CoreMatchers.nullValue())
+					//	.statusCode(HttpStatus.SC_CREATED)
+					.post(this.container);
+
 				if (postResponse.getStatusCode() != HttpStatus.SC_CREATED) {
-					System.err.println(SETUP_ERROR);
-					System.err.println("POST failed with status code: " + postResponse.getStatusCode());
-					System.err.println();
-					return;
+					throw new SkipException(Thread.currentThread().getStackTrace()[1].getMethodName(),
+							"Could not create test resource for MemberResourceTest, POST failed with status code: " + postResponse.getStatusCode(), skipLog);
 				}
 
 				this.memberResource = postResponse.getHeader(LOCATION);
 				if (this.memberResource == null) {
-					System.err.println(SETUP_ERROR);
-					System.err.println("Location response header missing");
-					System.err.println();
-					return;
+					throw new SkipException(Thread.currentThread().getStackTrace()[1].getMethodName(),
+							"Could not create test resource for MemberResourceTest, Location response header missing.", skipLog);
 				}
 			} catch (Exception e) {
-				System.err.println(SETUP_ERROR);
-				e.printStackTrace();
+				// Assert.fail(SETUP_ERROR, e);
+				throw new SkipException(Thread.currentThread().getStackTrace()[1].getMethodName(),
+						SETUP_ERROR, skipLog);
 			}
 		}
 	}

--- a/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.marmotta.commons.util.HashUtils;
 import org.apache.marmotta.commons.vocabulary.LDP;
+import org.hamcrest.CoreMatchers;
 import org.testng.Assert;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
@@ -66,27 +67,29 @@ public class NonRDFSourceTest extends CommonResourceTest {
 		// Create a resource to use for CommonResourceTest.
 		try {
 			Response response = buildBaseRequestSpecification()
+				.with()
 					.header(SLUG, slug)
 					.body(IOUtils.toByteArray(getClass().getResourceAsStream("/" + file)))
 					.contentType(mimeType)
-					.post(container);
+				.expect()
+				//	.statusCode(HttpStatus.SC_CREATED)
+				//	.header(LOCATION, CoreMatchers.notNullValue())
+				.post(container);
+
 			if (response.getStatusCode() != HttpStatus.SC_CREATED) {
-				System.err.println(SETUP_ERROR);
-				System.err.println("POST failed with status code: " + response.getStatusCode());
-				System.err.println();
-				return;
+				throw new SkipException(Thread.currentThread().getStackTrace()[1].getMethodName(),
+						"Could not create test resource for MemberResourceTest, POST failed with status code: " + response.getStatusCode(), skipLog);
 			}
 
 			nonRdfSource = response.getHeader(LOCATION);
 			if (nonRdfSource == null) {
-				System.err.println(SETUP_ERROR);
-				System.err.println("Location response header missing");
-				System.err.println();
-				return;
+				throw new SkipException(Thread.currentThread().getStackTrace()[1].getMethodName(),
+						"Could not create test resource for MemberResourceTest, Location response header missing.", skipLog);
 			}
 		} catch (Exception e) {
-			System.err.println(SETUP_ERROR);
-			e.printStackTrace();
+			// Assert.fail(SETUP_ERROR, e);
+			throw new SkipException(Thread.currentThread().getStackTrace()[1].getMethodName(),
+					SETUP_ERROR, skipLog);
 		}
 	}
 


### PR DESCRIPTION
IMHO it would be the right approach to throw a `SkipException()` instead of writing warnings to `System.err` if the resource to test cannot be created.

Maybe it is even better to *fail* the test if the setup could not be completed? 