### PR TITLE
Allow LDP Servers to include charset parameter in Turtle media type

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/mapper/RdfObjectMapper.java
+++ b/src/main/java/org/w3/ldp/testsuite/mapper/RdfObjectMapper.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 
 import org.w3.ldp.testsuite.http.MediaTypes;
+import org.w3.ldp.testsuite.matcher.HeaderMatchers;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
@@ -25,7 +26,7 @@ public class RdfObjectMapper implements ObjectMapper {
 	}
 
 	private String getLang(String mediaType) {
-		if (MediaTypes.TEXT_TURTLE.equals(mediaType)) {
+		if (HeaderMatchers.isTurtleCompatibleContentType().matches(mediaType)) {
 			return "TURTLE";
 		} else if (MediaTypes.APPLICATION_RDF_XML.equals(mediaType)) {
 			return "RDF/XML";

--- a/src/main/java/org/w3/ldp/testsuite/matcher/HeaderMatchers.java
+++ b/src/main/java/org/w3/ldp/testsuite/matcher/HeaderMatchers.java
@@ -17,6 +17,8 @@
  */
 package org.w3.ldp.testsuite.matcher;
 
+import java.util.regex.Pattern;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.CustomTypeSafeMatcher;
@@ -32,6 +34,7 @@ import javax.ws.rs.core.Link;
  */
 public class HeaderMatchers {
 
+	private static final Pattern TURTLE_REGEX = Pattern.compile("^" + MediaTypes.TEXT_TURTLE + "\\s*(;|$)");
 	/**
 	 * Regular expression matching valid ETag values.
 	 *
@@ -107,6 +110,22 @@ public class HeaderMatchers {
 			@Override
 			protected boolean matchesSafely(String item) {
 				return item.equals(MediaTypes.APPLICATION_LD_JSON) || item.equals(MediaTypes.APPLICATION_JSON);
+			}
+		};
+	}
+
+	/**
+	 * Matcher testing a Content-Type response header's compatibility with
+	 * Turtle (expects text/turtle).
+	 *
+	 * @return the matcher
+	 */
+	public static Matcher<String> isTurtleCompatibleContentType() {
+		return new CustomTypeSafeMatcher<String>("text/turtle") {
+			@Override
+			protected boolean matchesSafely(String item) {
+				return MediaTypes.TEXT_TURTLE.equals(item)
+						|| TURTLE_REGEX.matcher(item).find();
 			}
 		};
 	}

--- a/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
@@ -282,22 +282,22 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 	public void testGetResourceAcceptTurtle() {
 		// Accept: text/turtle
 		buildBaseRequestSpecification().header(ACCEPT, TEXT_TURTLE)
-				.expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
+				.expect().statusCode(isSuccessful()).contentType(HeaderMatchers.isTurtleCompatibleContentType())
 				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
 
 		// More complicated Accept header
 		buildBaseRequestSpecification().header(ACCEPT, "text/turtle;q=0.9,application/json;q=0.8")
-				.expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
+				.expect().statusCode(isSuccessful()).contentType(HeaderMatchers.isTurtleCompatibleContentType())
 				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
 
 		// Wildcard
 		buildBaseRequestSpecification().header(ACCEPT, "*/*")
-				.expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
+				.expect().statusCode(isSuccessful()).contentType(HeaderMatchers.isTurtleCompatibleContentType())
 				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
 
 		// Accept: text/*
 		buildBaseRequestSpecification().header(ACCEPT, "text/*")
-				.expect().statusCode(isSuccessful()).contentType(TEXT_TURTLE)
+				.expect().statusCode(isSuccessful()).contentType(HeaderMatchers.isTurtleCompatibleContentType())
 				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
 	}
 	


### PR DESCRIPTION
The media type text/turtle;charset=UTF-8 should be treated the same as text/turtle within the test suite.

This pull request changes the media type matching from equals to a regex.
