### PR TITLE
Don't assume the LDPR primary topic is the same as the LDPR location

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
@@ -117,7 +117,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 			String relationAbsoluteUri = resolveIfRelative(location, RELATIVE_URI);
 			assertTrue(
 					responseModel.contains(
-							responseModel.getResource(location),
+							getPrimaryTopic(responseModel, location),
 							DCTerms.relation,
 							responseModel.getResource(relationAbsoluteUri)
 					),
@@ -500,7 +500,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 			// Rename the subject of the request model so it matches the received location
 			// and intersect both models.
 			ResourceUtils.renameResource(
-					requestModel.getResource(""), location);
+					requestModel.getResource(""), getPrimaryTopic(responseModel, location).getURI());
 			Model intersectionModel = requestModel.intersection(responseModel);
 
 			// OK if the result is not empty

--- a/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
@@ -2,6 +2,9 @@ package org.w3.ldp.testsuite.test;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
+import com.hp.hpl.jena.rdf.model.NodeIterator;
+import com.hp.hpl.jena.rdf.model.Property;
+import com.hp.hpl.jena.rdf.model.ResIterator;
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.util.ResourceUtils;
 import com.hp.hpl.jena.vocabulary.DCTerms;
@@ -221,6 +224,27 @@ public abstract class LdpTest {
 		resource.addProperty(DCTerms.description, "Issues that need to be fixed.");
 
 		return model;
+	}
+
+	protected Resource getPrimaryTopic(Model model, String location) {
+		Resource loc = model.getResource(location);
+		Property insertedContentRelation = model.getProperty(LDP.insertedContentRelation.stringValue());
+		NodeIterator relations = model.listObjectsOfProperty(loc, insertedContentRelation);
+		if (relations.hasNext()) {
+			String relation = relations.next().toString();
+			if (LDP.MemberSubject.stringValue().equals(relation)) {
+				return loc;
+			} else {
+				Property primaryTopic = model.getProperty(relation);
+				return model.listObjectsOfProperty(loc, primaryTopic).next().asResource();
+			}
+		}
+		ResIterator bugs = model.listSubjectsWithProperty(RDF.type, model.createResource("http://example.com/ns#Bug"));
+		if (bugs.hasNext()) {
+			return bugs.nextResource();
+		} else {
+			return loc;
+		}
 	}
 
 	protected Model postContent() {

--- a/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
@@ -91,7 +91,7 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 		Model model = response.as(Model.class, new RdfObjectMapper(resourceUri));
 
 		// Add a statement with a relative URI.
-		model.getResource(resourceUri).addProperty(DCTerms.relation, model.getResource(RELATIVE_URI));
+		getPrimaryTopic(model, resourceUri).addProperty(DCTerms.relation, model.getResource(RELATIVE_URI));
 
 		// Put the resource back using relative URIs.
 		Response put = buildBaseRequestSpecification()
@@ -116,7 +116,7 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 		String relationAbsoluteUri = resolveIfRelative(resourceUri, RELATIVE_URI);
 		assertTrue(
 				model.contains(
-						model.getResource(resourceUri),
+						getPrimaryTopic(model, resourceUri),
 						DCTerms.relation,
 						model.getResource(relationAbsoluteUri)
 				),
@@ -184,7 +184,7 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 			approval = STATUS.WG_APPROVED)
 	public void testContainsRdfType() {
 		Model containerModel = getAsModel(getResourceUri());
-		Resource r = containerModel.getResource(getResourceUri());
+		Resource r = getPrimaryTopic(containerModel, getResourceUri());
 		assertTrue(r.hasProperty(RDF.type), "LDP-RS representation has no explicit rdf:type");
 	}
 
@@ -482,7 +482,7 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 	}
 
 	protected void modifyProperty(Model m, String resourceUri, String property) {
-		Resource r = m.getResource(resourceUri);
+		Resource r = getPrimaryTopic(m, resourceUri);
 		Property p = m.createProperty(property);
 		r.removeAll(p);
 		// Don't sweat the value or datatype since we expect the PUT to fail anyway.
@@ -579,7 +579,7 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 
 		String eTag = response.getHeader(ETAG);
 		Model originalModel = response.as(Model.class, new RdfObjectMapper(resourceUri));
-		Resource resource = originalModel.getResource(resourceUri);
+		Resource resource = getPrimaryTopic(originalModel, resourceUri);
 
 		assertNotNull(resource, "Expected to location resource in response for "+resourceUri);
 
@@ -618,11 +618,11 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 		Model updatedModel = response.as(Model.class, new RdfObjectMapper(resourceUri));
 
 		// Validate the updated statement/triple is there.
-		Resource updatedResource = updatedModel.getResource(resourceUri);
+		Resource updatedResource = getPrimaryTopic(updatedModel, resourceUri);
 		assertTrue(updatedResource.hasProperty(DCTerms.title, UPDATED_TITLE), "Expected updated resource to have title: " + UPDATED_TITLE);
 
 		// Make sure it's the only title
-		Resource diffResource = updatedModel.getResource(resourceUri);
+		Resource diffResource = getPrimaryTopic(updatedModel, resourceUri);
 		StmtIterator diffTitleProps = diffResource.listProperties(DCTerms.title);
 		int diffTitlePropSize = diffTitleProps.toSet().size();
 		assertEquals(diffTitlePropSize, 1, "Updated resource contains additional unexpected dcterms:title changes.");


### PR DESCRIPTION
To support indirect containers, the test suite must distinguish between the LDPR primary topic and the LDPR location.

This pull-request adds a getPrimaryTopic method that tries to guess the LDPR primary topic. It uses the ldp:insertedContentRelation for containers and the rdf:type ex:Bug for resources to find the primary topic.
