### PR TITLE
Don't test wildcard Accept header (outside spec)

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
@@ -289,16 +289,6 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 		buildBaseRequestSpecification().header(ACCEPT, "text/turtle;q=0.9,application/json;q=0.8")
 				.expect().statusCode(isSuccessful()).contentType(HeaderMatchers.isTurtleCompatibleContentType())
 				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
-
-		// Wildcard
-		buildBaseRequestSpecification().header(ACCEPT, "*/*")
-				.expect().statusCode(isSuccessful()).contentType(HeaderMatchers.isTurtleCompatibleContentType())
-				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
-
-		// Accept: text/*
-		buildBaseRequestSpecification().header(ACCEPT, "text/*")
-				.expect().statusCode(isSuccessful()).contentType(HeaderMatchers.isTurtleCompatibleContentType())
-				.when().get(getResourceUri()).as(Model.class, new RdfObjectMapper(getResourceUri()));
 	}
 	
 	@Test(


### PR DESCRIPTION
The spec says Turtle MUST be responded when Turtle is requested in the Accept header. If Turtle is not present in the Accept header, it the server might not return Turtle and still comply with the spec.

This addresses issue #198.

An Accept header of "`*/*`" is (for most purposes) similar to IE's Accept header of "image/jpeg, application/x-ms-application, image/gif, application/xaml+xml, image/pjpeg, application/x-ms-xbap, application/x-shockwave-flash, application/msword, `*/*`". Anyone that wants to make their LDPR available to IE is going to have trouble with section 4.3.2.2 and should not be included in testing testGetResourceAcceptTurtle.

4.3.2.1 LDP servers MUST respond with a Turtle representation of the requested LDP-RS when the request includes an Accept header specifying text/turtle, unless HTTP content negotiation requires a different outcome.
http://www.w3.org/TR/ldp/#ldprs-get-turtle
