### PR TITLE
simplify JSON-LD serialization

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/mapper/RdfObjectMapper.java
+++ b/src/main/java/org/w3/ldp/testsuite/mapper/RdfObjectMapper.java
@@ -2,7 +2,12 @@ package org.w3.ldp.testsuite.mapper;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonArray;
+import org.apache.jena.atlas.json.JsonObject;
+import org.apache.jena.atlas.json.JsonValue;
 import org.w3.ldp.testsuite.http.MediaTypes;
 import org.w3.ldp.testsuite.matcher.HeaderMatchers;
 
@@ -56,6 +61,39 @@ public class RdfObjectMapper implements ObjectMapper {
 		rdfWriter.setProperty("relativeURIs", "same-document");
 		rdfWriter.setProperty("allowBadURIs", "true");
 		rdfWriter.write(model, out, baseURI);
+
+		if ("JSON-LD".equals(lang)) {
+			// Do some additional processing to simplify the JSON-LD if
+			// possible and remove Jena's urn:x-arq:DefaultGraphNode.
+			try {
+				JsonObject json = JSON.parse(out.toString("UTF-8"));
+				JsonValue graph = json.get("@graph");
+				JsonValue jsonContext = json.get("@context");
+				if (graph != null && graph.isArray()) {
+					out = new ByteArrayOutputStream();
+					JsonArray a = graph.getAsArray();
+
+					if (a.size() == 1) {
+						// If size is 1, @graph isn't necessary.
+						JsonObject content = a.get(0).getAsObject();
+						if (jsonContext != null) {
+							// Preserve the context if it's there.
+							content.put("@context", jsonContext);
+						}
+
+						JSON.write(out, content);
+					} else {
+						// Remove graph ID urn:x-arq:DefaultGraphNode. If @id is
+						// left out, it is the implicit default graph.
+						// See https://issues.apache.org/jira/browse/JENA-794
+						json.remove("@id");
+						JSON.write(out, json);
+					}
+				}
+			} catch (UnsupportedEncodingException e) {
+				throw new RuntimeException(e);
+			}
+		}
 
 		return out.toByteArray();
 	}


### PR DESCRIPTION
- Don't use @graph if it's not needed
- Make sure Jena's serialization doesn't use
  graph URI urn:x-arq:DefaultGraphNode

Fixes #197
