### PR TITLE
fix setup and teardown methods

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
@@ -42,24 +42,29 @@ public abstract class LdpTest {
 	public final static String SKIPPED_LOG_FILENAME = "skipped.log";
 
 	public final static String HTTP_LOG_FILENAME = "http.log";
-	public static final DateFormat df = DateFormat.getDateTimeInstance();
-	
+	public final static DateFormat df = DateFormat.getDateTimeInstance();
+
 	public final static String DEFAULT_MODEL_TYPE = "http://example.com/ns#Bug";
+
+	/*
+	 * The following properties are marked static because commonSetup() is only called
+	 * one time, even if several test classes inherit from LdpTest.
+	 */
 
 	/**
 	 * Alternate content to use on POST requests
 	 */
-	private Model postModel;
+	private static Model postModel;
 
 	/**
 	 * For HTTP details on validation failures
 	 */
-	protected PrintWriter httpLog;
+	protected static PrintWriter httpLog;
 
 	/**
 	 * For skipped test logging
 	 */
-	protected PrintWriter skipLog;
+	protected static PrintWriter skipLog;
 
 	/**
 	 * Builds a model from a turtle representation in a file
@@ -105,11 +110,16 @@ public abstract class LdpTest {
 	 */
 	@BeforeSuite(alwaysRun = true)
 	@Parameters({"output", "postTtl", "httpLogging", "skipLogging"})
-	public void setup(String outputDir, @Optional String postTtl, @Optional String httpLogging, @Optional String skipLogging) throws IOException {
+	public void commonSetup(String outputDir, @Optional String postTtl, @Optional String httpLogging, @Optional String skipLogging) throws IOException {
+
+		/*
+		 * Note: This method is only called one time, even if many classes inherit
+		 * from LdpTest. Don't set non-static members here.
+		 */
+
 		postModel = readModel(postTtl);
 
 		File dir = new File(outputDir);
-		//FileUtils.deleteDirectory(dir);
 		dir.mkdirs();
 
 		if ("true".equals(httpLogging)) {
@@ -139,7 +149,7 @@ public abstract class LdpTest {
 	}
 
 	@AfterSuite(alwaysRun = true)
-	public void tearDown() {
+	public void commonTearDown() {
 		if (httpLog != null) {
 			httpLog.println();
 			httpLog.flush();
@@ -183,17 +193,6 @@ public abstract class LdpTest {
 	 * via various reporters.
 	 */
 	public static final String MANUAL = "MANUAL";
-
-	private boolean warnings = false;
-
-	public boolean getWarnings() {
-		return warnings;
-	}
-
-	/**
-	 * If true, log HTTP request and response details on errors.
-	 */
-	protected boolean httpLogging = false;
 
 	/**
 	 * Build a base RestAssured {@link com.jayway.restassured.specification.RequestSpecification}.

--- a/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/MemberResourceTest.java
@@ -29,9 +29,12 @@ public class MemberResourceTest extends RdfSourceTest {
 		super(auth);
 	}
 
+	/*
+	 * Creates a resource to test if there's no memberResource test parameter.
+	 */
 	@Parameters({"memberResource", "directContainer", "indirectContainer", "basicContainer", "memberTtl"})
 	@BeforeSuite(alwaysRun = true)
-	public void setup(@Optional String memberResource, @Optional String directContainer,
+	public void createTestResource(@Optional String memberResource, @Optional String directContainer,
 			@Optional String indirectContainer, @Optional String basicContainer,
 			@Optional String memberTtl) {
 		// If resource is defined, use that. Otherwise, fall back to creating one from one of the containers.
@@ -89,8 +92,12 @@ public class MemberResourceTest extends RdfSourceTest {
 		return memberResource;
 	}
 
+	/*
+	 * Deletes the test resource to clean up if it's wasn't provided using the
+	 * memberResource test parameter.
+	 */
 	@AfterSuite(alwaysRun = true)
-	public void tearDown() {
+	public void deleteTestResource() {
 		// If container isn't null, we created the resource ourselves. To clean up, delete the resource.
 		if (container != null) {
 			buildBaseRequestSpecification().delete(memberResource);

--- a/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
@@ -43,7 +43,7 @@ public class NonRDFSourceTest extends CommonResourceTest {
 
 	@Parameters({ "basicContainer", "directContainer", "indirectContainer" })
 	@BeforeSuite(alwaysRun = true)
-	public void setup(@Optional String basicContainer, @Optional String directContainer, @Optional String indirectContainer) {
+	public void createTestResource(@Optional String basicContainer, @Optional String directContainer, @Optional String indirectContainer) {
 		if (StringUtils.isNotBlank(basicContainer)) {
 			container = basicContainer;
 		} else if (StringUtils.isNotBlank(directContainer)) {
@@ -88,7 +88,7 @@ public class NonRDFSourceTest extends CommonResourceTest {
 	}
 
 	@AfterSuite(alwaysRun = true)
-	public void tearDown() {
+	public void deleteTestResource() {
 		if (nonRdfSource != null) {
 			buildBaseRequestSpecification().delete(nonRdfSource);
 		}


### PR DESCRIPTION
- Only set static variables from LdpTest setup. Setup is only called
  once even when several classes inherit from LdpTest.
- Change setup and tear down method names so we don't accidentally
  override them in subclasses.

See https://github.com/cbeust/testng/issues/313

Fixes #192
