### PR TITLE
Make sure common NR resource slug does not conflict with test specific

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/NonRDFSourceTest.java
@@ -56,8 +56,8 @@ public class NonRDFSourceTest extends CommonResourceTest {
 					skipLog);
 		}
 
-		final String slug = "test",
-				file = slug + ".png",
+		final String slug = "non-rdf-source",
+				file = "test.png",
 				mimeType = "image/png";
 
 		// Create a resource to use for CommonResourceTest.


### PR DESCRIPTION
Some NonRDFSourceTest tests create their own NR resource and by using the same slug they might get a Conflict. This pull request uses a different name for the common NR resource slug to avoid potential conflicts.
