### PR TITLE
Make the relative URI used for testing a configurable option

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/LdpTestSuite.java
+++ b/src/main/java/org/w3/ldp/testsuite/LdpTestSuite.java
@@ -233,6 +233,10 @@ public class LdpTestSuite {
 			parameters.put("readOnlyProp", options.getOptionValue("read-only-prop"));
 		}
 
+		if (options.hasOption("relative-uri")) {
+			parameters.put("relativeUri", options.getOptionValue("relative-uri"));
+		}
+
 		if (options.hasOptionWithValue("auth")) {
 			final String auth = options.getOptionValue("auth");
 			if (auth.contains(":")) {

--- a/src/main/java/org/w3/ldp/testsuite/RunLdpTestSuite.java
+++ b/src/main/java/org/w3/ldp/testsuite/RunLdpTestSuite.java
@@ -21,6 +21,7 @@ public class RunLdpTestSuite {
 
 		addContResOption();
 		addReadOnlyOption();
+		addRelativeUriOption();
 
 		LdpTestSuite.executeTestSuite(args, options, "ldp-testsuite");
 	}
@@ -45,6 +46,14 @@ public class RunLdpTestSuite {
 	private static void addReadOnlyOption() {
 		options.addOption(OptionBuilder.withLongOpt("read-only-prop")
 				.withDescription("a read-only property to test error conditions")
+				.hasArg().withArgName("uri")
+				.create());
+	}
+
+	@SuppressWarnings("static-access")
+	private static void addRelativeUriOption() {
+		options.addOption(OptionBuilder.withLongOpt("relative-uri")
+				.withDescription("a relative uri to test relative uri resolution")
 				.hasArg().withArgName("uri")
 				.create());
 	}

--- a/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/CommonContainerTest.java
@@ -72,12 +72,13 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 					+ "Request-URI when the resource already exists, and to "
 					+ "the URI of the created resource when the request results "
 					+ "in the creation of a new resource.")
+	@Parameters("relativeUri")
 	@SpecTest(
 			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-defbaseuri",
 			testMethod = METHOD.AUTOMATED,
 			approval = STATUS.WG_APPROVED,
 			comment = "Covers only part of the specification requirement. ")
-	public void testRelativeUriResolutionPost() {
+	public void testRelativeUriResolutionPost(@Optional String relativeUri) {
 		skipIfMethodNotAllowed(HttpMethod.POST);
 
 		if (restrictionsOnPostContent()) {
@@ -86,10 +87,14 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 					+ "The requirement needs to be tested manually.", skipLog);
 		}
 
+		if (relativeUri == null) {
+			relativeUri = RELATIVE_URI;
+		}
+
 		// POST content with a relative URI (other than the null relative URI).
 		Model requestModel = postContent();
 		Resource r = requestModel.getResource("");
-		r.addProperty(DCTerms.relation, requestModel.createResource(RELATIVE_URI));
+		r.addProperty(DCTerms.relation, requestModel.createResource(relativeUri));
 
 		String containerUri = getResourceUri();
 		Response postResponse = buildBaseRequestSpecification()
@@ -114,7 +119,7 @@ public abstract class CommonContainerTest extends RdfSourceTest {
 			// Check that the dcterms:relation URI was resolved relative to the
 			// URI assigned to the new resource (location).
 			Model responseModel = getResponse.as(Model.class, new RdfObjectMapper(location));
-			String relationAbsoluteUri = resolveIfRelative(location, RELATIVE_URI);
+			String relationAbsoluteUri = resolveIfRelative(location, relativeUri);
 			assertTrue(
 					responseModel.contains(
 							getPrimaryTopic(responseModel, location),

--- a/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
@@ -265,7 +265,7 @@ public abstract class LdpTest {
 	 *
 	 * <p>
 	 * This method is used for
-	 * {@link CommonContainerTest#testRelativeUriResolutionPost()}.
+	 * {@link CommonContainerTest#testRelativeUriResolutionPost(String)}.
 	 * </p>
 	 *
 	 * @return true if there are restrictions on what triples are allowed; false

--- a/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/RdfSourceTest.java
@@ -67,16 +67,21 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 					+ "Request-URI when the resource already exists, and to "
 					+ "the URI of the created resource when the request results "
 					+ "in the creation of a new resource.")
+	@Parameters("relativeUri")
 	@SpecTest(
 			specRefUri = LdpTestSuite.SPEC_URI + "#ldpr-gen-defbaseuri",
 			testMethod = METHOD.AUTOMATED,
 			approval = STATUS.WG_APPROVED)
-	public void testRelativeUriResolutionPut() {
+	public void testRelativeUriResolutionPut(@Optional String relativeUri) {
 		skipIfMethodNotAllowed(HttpMethod.PUT);
 
 		if (restrictionsOnTestResourceContent()) {
 			throw new SkipException(Thread.currentThread().getStackTrace()[1].getMethodName(),
 					MSG_PUT_RESTRICTIONS, skipLog);
+		}
+
+		if (relativeUri == null) {
+			relativeUri = RELATIVE_URI;
 		}
 
 		String resourceUri = getResourceUri();
@@ -92,7 +97,7 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 		Model model = response.as(Model.class, new RdfObjectMapper(resourceUri));
 
 		// Add a statement with a relative URI.
-		getPrimaryTopic(model, resourceUri).addProperty(DCTerms.relation, model.getResource(RELATIVE_URI));
+		getPrimaryTopic(model, resourceUri).addProperty(DCTerms.relation, model.getResource(relativeUri));
 
 		// Put the resource back using relative URIs.
 		Response put = buildBaseRequestSpecification()
@@ -114,7 +119,7 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 				.get(resourceUri).as(Model.class, new RdfObjectMapper(resourceUri));
 
 		// Verify the change.
-		String relationAbsoluteUri = resolveIfRelative(resourceUri, RELATIVE_URI);
+		String relationAbsoluteUri = resolveIfRelative(resourceUri, relativeUri);
 		assertTrue(
 				model.contains(
 						getPrimaryTopic(model, resourceUri),
@@ -546,7 +551,7 @@ public abstract class RdfSourceTest extends CommonResourceTest {
 	 *
 	 * <p>
 	 * This method is used for {@link #testPutReplacesResource()} and
-	 * {@link #testRelativeUriResolutionPut()}.
+	 * {@link #testRelativeUriResolutionPut(String)}.
 	 * </p>
 	 *
 	 * @return true if there are restrictions on what triples are allowed; false


### PR DESCRIPTION
Our LDP implementation requires that RDF assertions within resources are resolvable at the resource's URI. We don't allow clients to make assertions about arbitrary resources in the resource's graph, but, say, a resource with a relative hash URI is just fine.

This patch makes the relative URI configurable, so implementations (like ours) who support a limited set of resource creation can still pass the relative URI test.
