### PR TITLE
Look for correct option for skip logging

### DIFF
--- a/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
+++ b/src/main/java/org/w3/ldp/testsuite/test/LdpTest.java
@@ -138,7 +138,7 @@ public abstract class LdpTest {
 			}
 		}
 
-		if ("true".equals(httpLogging)) {
+		if ("true".equals(skipLogging)) {
 			File file = new File(dir, SKIPPED_LOG_FILENAME);
 			try {
 				skipLog = new PrintWriter(new BufferedWriter(new FileWriter(file, true)));


### PR DESCRIPTION
We were incorrectly looking at --httpLogging to decide if we should log
skipped tests. We should be looking at --skipLogging.