### PR TITLE
Work around bug with empty response bodies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>2.3.3</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.openrdf.sesame</groupId>
@@ -249,7 +249,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>2.12.0</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.rendersnake</groupId>

--- a/src/main/java/org/w3/ldp/testsuite/mapper/RdfObjectMapper.java
+++ b/src/main/java/org/w3/ldp/testsuite/mapper/RdfObjectMapper.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.jena.atlas.json.JSON;
 import org.apache.jena.atlas.json.JsonArray;
 import org.apache.jena.atlas.json.JsonObject;
@@ -45,9 +46,13 @@ public class RdfObjectMapper implements ObjectMapper {
 
 	@Override
 	public Object deserialize(ObjectMapperDeserializationContext context) {
-		InputStream input = context.getDataToDeserialize().asInputStream();
+		String input = context.getDataToDeserialize().asString();
 		Model m = ModelFactory.createDefaultModel();
-		m.read(input, baseURI, getLang(context.getContentType()));
+
+		if (!input.isEmpty()) {
+			m.read(IOUtils.toInputStream(input), baseURI, getLang(context.getContentType()));
+		}
+
 		return m;
 	}
 


### PR DESCRIPTION
We have an LDP implementation does not add server-managed triples, which triggers a `NullPointerError` within RestAssured (reported upstream as https://github.com/jayway/rest-assured/issues/642).

Handling the response graph as a string does not cause the same problem. It seems like the graphs in the test suite are sufficiently small that using strings oughtn't cause too many problems.
